### PR TITLE
feat: correctly ordering the content api responses

### DIFF
--- a/XerifeTv.CMS/Models/Channel/ChannelRepository.cs
+++ b/XerifeTv.CMS/Models/Channel/ChannelRepository.cs
@@ -42,7 +42,8 @@ public sealed class ChannelRepository(IOptions<DBSettings> options)
       .Aggregate()
       .Group(
         r => r.Category,
-        g => new ItemsByCategory<ChannelEntity>(g.Key, g.Take(limit).ToList()))
+        g => 
+          new ItemsByCategory<ChannelEntity>(g.Key, g.OrderByDescending(x => x.CreateAt).Take(limit).ToList()))
       .ToListAsync();
   }
 }

--- a/XerifeTv.CMS/Models/Content/ContentService.cs
+++ b/XerifeTv.CMS/Models/Content/ContentService.cs
@@ -35,10 +35,11 @@ public sealed class ContentService(
       response = await _movieRepository.GetGroupByCategoryAsync(limit ?? limitPartialResult);
       _cacheService.SetValue(cacheKey, response);
     }
-
+    
     var result = response.Select(x =>
       new ItemsByCategory<GetMovieContentResponseDto>(
-        x.Category, x.Items.Select(GetMovieContentResponseDto.FromEntity)));
+        x.Category, x.Items.Select(GetMovieContentResponseDto.FromEntity)))
+      .OrderBy(x => x.Category);
 
     return Result<IEnumerable<ItemsByCategory<GetMovieContentResponseDto>>>
       .Success(result);
@@ -76,7 +77,8 @@ public sealed class ContentService(
 
     var result = response.Select(x =>
       new ItemsByCategory<GetSeriesContentResponseDto>(
-        x.Category, x.Items.Select(GetSeriesContentResponseDto.FromEntity)));
+        x.Category, x.Items.Select(GetSeriesContentResponseDto.FromEntity)))
+      .OrderBy(x => x.Category);
 
     return Result<IEnumerable<ItemsByCategory<GetSeriesContentResponseDto>>>
       .Success(result);
@@ -129,7 +131,8 @@ public sealed class ContentService(
 
     var result = response.Select(x =>
       new ItemsByCategory<GetChannelContentResponseDto>(
-        x.Category, x.Items.Select(GetChannelContentResponseDto.FromEntity)));
+        x.Category, x.Items.Select(GetChannelContentResponseDto.FromEntity)))
+      .OrderBy(x => x.Category);
 
     return Result<IEnumerable<ItemsByCategory<GetChannelContentResponseDto>>>
       .Success(result);

--- a/XerifeTv.CMS/Models/Movie/MovieRepository.cs
+++ b/XerifeTv.CMS/Models/Movie/MovieRepository.cs
@@ -43,7 +43,8 @@ public sealed class MovieRepository(IOptions<DBSettings> options)
       .Aggregate()
       .Group(
         r => r.Category, 
-        g => new ItemsByCategory<MovieEntity>(g.Key, g.Take(limit).ToList()))
+        g => 
+          new ItemsByCategory<MovieEntity>(g.Key, g.OrderByDescending(x => x.CreateAt).Take(limit).ToList()))
       .ToListAsync();
   }
 }

--- a/XerifeTv.CMS/Models/Series/SeriesRepository.cs
+++ b/XerifeTv.CMS/Models/Series/SeriesRepository.cs
@@ -72,7 +72,8 @@ public sealed class SeriesRepository(IOptions<DBSettings> options)
       .Aggregate()
       .Group(
         r => r.Category,
-        g => new ItemsByCategory<SeriesEntity>(g.Key, g.Take(limit).ToList()))
+        g => 
+          new ItemsByCategory<SeriesEntity>(g.Key, g.OrderByDescending(x => x.CreateAt).Take(limit).ToList()))
       .ToListAsync();
   }
 


### PR DESCRIPTION
correctly ordering the content api responses (categorical in alphabetical order and items by registration date in descending order)