### PR TITLE
refactor: category filter comparison to use equals and trim

### DIFF
--- a/XerifeTv.CMS/Models/Channel/ChannelRepository.cs
+++ b/XerifeTv.CMS/Models/Channel/ChannelRepository.cs
@@ -18,7 +18,7 @@ public sealed class ChannelRepository(IOptions<DBSettings> options)
     Expression<Func<ChannelEntity, bool>> filterExpression = dto.Filter switch
     {
       EChannelSearchFilter.TITLE => r => r.Title.Contains(dto.Search, StringComparison.CurrentCultureIgnoreCase),
-      EChannelSearchFilter.CATEGORY => r => r.Category.Contains(dto.Search, StringComparison.CurrentCultureIgnoreCase),
+      EChannelSearchFilter.CATEGORY => r => r.Category.Equals(dto.Search.Trim(), StringComparison.CurrentCultureIgnoreCase),
       _ => r => r.Title.Contains(dto.Search, StringComparison.CurrentCultureIgnoreCase)
     };
 

--- a/XerifeTv.CMS/Models/Movie/MovieRepository.cs
+++ b/XerifeTv.CMS/Models/Movie/MovieRepository.cs
@@ -18,7 +18,7 @@ public sealed class MovieRepository(IOptions<DBSettings> options)
     Expression<Func<MovieEntity, bool>> filterExpression = dto.Filter switch
     {
       EMovieSearchFilter.TITLE => r => r.Title.Contains(dto.Search, StringComparison.CurrentCultureIgnoreCase),
-      EMovieSearchFilter.CATEGORY => r => r.Category.Contains(dto.Search, StringComparison.CurrentCultureIgnoreCase),
+      EMovieSearchFilter.CATEGORY => r => r.Category.Equals(dto.Search.Trim(), StringComparison.CurrentCultureIgnoreCase),
       EMovieSearchFilter.RELEASE_YEAR => r => r.ReleaseYear.Equals(int.Parse(dto.Search)),
       _ => r => r.Title.Contains(dto.Search, StringComparison.CurrentCultureIgnoreCase)
     };

--- a/XerifeTv.CMS/Models/Series/SeriesRepository.cs
+++ b/XerifeTv.CMS/Models/Series/SeriesRepository.cs
@@ -46,7 +46,7 @@ public sealed class SeriesRepository(IOptions<DBSettings> options)
   {
     Expression<Func<SeriesEntity, bool>> filterExpression = dto.Filter switch
     {
-      ESeriesSearchFilter.CATEGORY => r => r.Category.Contains(dto.Search, StringComparison.CurrentCultureIgnoreCase),
+      ESeriesSearchFilter.CATEGORY => r => r.Category.Equals(dto.Search.Trim(), StringComparison.CurrentCultureIgnoreCase),
       _ => r => r.Title.Contains(dto.Search, StringComparison.CurrentCultureIgnoreCase)
     };
 


### PR DESCRIPTION
Instead of using the container for the category filter comparison, I now use the equals method and trim to remove any leading or trailing spaces from the string