### PR TITLE
feat(auth): implement Google login using Strategy pattern

### DIFF
--- a/XerifeTv.CMS/Controllers/UsersController.cs
+++ b/XerifeTv.CMS/Controllers/UsersController.cs
@@ -12,6 +12,7 @@ namespace XerifeTv.CMS.Controllers;
 public class UsersController(
 	IUserService _userService, 
 	IAuthService _authService,
+	IConfiguration _configuration,
 	ILogger<UsersController> _logger) : Controller
 {
 	private readonly CookieOptions _cookieOptions = new()
@@ -41,6 +42,8 @@ public class UsersController(
 		if (User.Identity != null && User.Identity.IsAuthenticated)
 			return RedirectToAction("Index", "Home");
 
+		ViewBag.GoogleClientId = _configuration["OAuth2Google:ClientId"];
+
 		return View();
 	}
 
@@ -53,6 +56,7 @@ public class UsersController(
 		if (response.IsFailure)
 		{
 			TempData["Notification"] = MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty);
+			ViewBag.GoogleClientId = _configuration["OAuth2Google:ClientId"];
 			_logger.LogInformation("There was an unsuccessful login attempt");
 			return View();
 		}

--- a/XerifeTv.CMS/Modules/Authentication/Dtos/Request/LoginRequestDto.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Dtos/Request/LoginRequestDto.cs
@@ -1,5 +1,9 @@
-﻿namespace XerifeTv.CMS.Modules.Authentication.Dtos.Request;
+﻿using XerifeTv.CMS.Modules.Authentication.Enums;
+
+namespace XerifeTv.CMS.Modules.Authentication.Dtos.Request;
 
 public record LoginRequestDto(
     string UserNameOrEmail,
-    string Password);
+    string Password,
+    ELoginProvider Provider,
+    string ExternalToken);

--- a/XerifeTv.CMS/Modules/Authentication/Dtos/Response/GoogleTokenPayloadDto.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Dtos/Response/GoogleTokenPayloadDto.cs
@@ -1,0 +1,8 @@
+﻿using System.Text.Json.Serialization;
+
+namespace XerifeTv.CMS.Modules.Authentication.Dtos.Response;
+
+public record GoogleTokenPayloadDto(
+	[property: JsonPropertyName("aud")] string Aud,
+	[property: JsonPropertyName("exp")] string Exp,
+	[property: JsonPropertyName("email")] string Email);

--- a/XerifeTv.CMS/Modules/Authentication/Enums/ELoginProvider.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Enums/ELoginProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace XerifeTv.CMS.Modules.Authentication.Enums;
+
+public enum ELoginProvider
+{
+	Basic = 1,
+	Google = 2
+}

--- a/XerifeTv.CMS/Modules/Authentication/Interfaces/ILoginStrategy.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Interfaces/ILoginStrategy.cs
@@ -1,0 +1,12 @@
+﻿using XerifeTv.CMS.Modules.Authentication.Dtos.Request;
+using XerifeTv.CMS.Modules.Authentication.Dtos.Response;
+using XerifeTv.CMS.Modules.Authentication.Enums;
+using XerifeTv.CMS.Modules.Common;
+
+namespace XerifeTv.CMS.Modules.Authentication.Interfaces;
+
+public interface ILoginStrategy
+{
+	Task<Result<LoginResponseDto>> AuthenticateAsync(LoginRequestDto dto);
+	bool CanHandle(ELoginProvider loginProvider);
+}

--- a/XerifeTv.CMS/Modules/Authentication/Services/BasicLoginStrategy.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Services/BasicLoginStrategy.cs
@@ -1,0 +1,51 @@
+﻿using XerifeTv.CMS.Modules.Authentication.Dtos.Request;
+using XerifeTv.CMS.Modules.Authentication.Dtos.Response;
+using XerifeTv.CMS.Modules.Authentication.Enums;
+using XerifeTv.CMS.Modules.Authentication.Interfaces;
+using XerifeTv.CMS.Modules.Common;
+using XerifeTv.CMS.Modules.User.Interfaces;
+using XerifeTv.CMS.Shared.Helpers;
+
+namespace XerifeTv.CMS.Modules.Authentication.Services;
+
+public class BasicLoginStrategy(IUserService _userService, ITokenService _tokenService) : ILoginStrategy
+{
+	public async Task<Result<LoginResponseDto>> AuthenticateAsync(LoginRequestDto dto)
+	{
+		try
+		{
+			var response = RegexHelper.IsValidEmail(dto.UserNameOrEmail)
+				? await _userService.GetByEmailAsync(dto.UserNameOrEmail)
+				: await _userService.GetByUsernameAsync(dto.UserNameOrEmail);
+
+			if (response.IsFailure)
+				return Result<LoginResponseDto>.Failure(response.Error);
+
+			var userResult = response.Data!;
+
+			var isPasswordCorrectResponse = await _userService.IsPasswordCorrect(userResult.Id, dto.Password);
+
+			if (isPasswordCorrectResponse.IsFailure)
+				return Result<LoginResponseDto>.Failure(isPasswordCorrectResponse.Error);
+
+			if (!isPasswordCorrectResponse.Data)
+				return Result<LoginResponseDto>.Failure(new Error("401", "Credenciais invalidas"));
+
+			if (userResult.Blocked)
+				return Result<LoginResponseDto>.Failure(new Error("403", "Usuario bloqueado"));
+
+			return Result<LoginResponseDto>.Success(
+				new LoginResponseDto(
+					_tokenService.GenerateToken(userResult.UserName, userResult.Role),
+					_tokenService.GenerateRefreshToken(userResult.UserName)));
+		}
+		catch (Exception ex)
+		{
+			var error = new Error("500", ex.InnerException?.Message ?? ex.Message);
+			return Result<LoginResponseDto>.Failure(error);
+		}
+	}
+
+	public bool CanHandle(ELoginProvider loginProvider)
+		=> loginProvider == ELoginProvider.Basic;
+}

--- a/XerifeTv.CMS/Modules/Authentication/Services/GoogleLoginStrategy.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Services/GoogleLoginStrategy.cs
@@ -1,0 +1,64 @@
+﻿using System.Text.Json;
+using XerifeTv.CMS.Modules.Authentication.Dtos.Request;
+using XerifeTv.CMS.Modules.Authentication.Dtos.Response;
+using XerifeTv.CMS.Modules.Authentication.Enums;
+using XerifeTv.CMS.Modules.Authentication.Interfaces;
+using XerifeTv.CMS.Modules.Common;
+using XerifeTv.CMS.Modules.User.Interfaces;
+
+namespace XerifeTv.CMS.Modules.Authentication.Services;
+
+public class GoogleLoginStrategy(
+	IUserService _userService,
+	ITokenService _tokenService,
+	IConfiguration _configuration) : ILoginStrategy
+{
+	public async Task<Result<LoginResponseDto>> AuthenticateAsync(LoginRequestDto dto)
+	{
+		try
+		{
+			var httpClient = new HttpClient();
+			var response = await httpClient.GetAsync($"https://oauth2.googleapis.com/tokeninfo?id_token={dto.ExternalToken}");
+
+			if (!response.IsSuccessStatusCode)
+				return Result<LoginResponseDto>.Failure(new Error("401", "Erro ao validar o token Google"));
+
+			var content = await response.Content.ReadAsStringAsync();
+			var payload = JsonSerializer.Deserialize<GoogleTokenPayloadDto>(content);
+
+			if (payload == null)
+				return Result<LoginResponseDto>.Failure(new Error("401", "Erro ao validar o token Google"));
+
+			if (payload.Aud != _configuration["OAuth2Google:ClientId"])
+				return Result<LoginResponseDto>.Failure(new Error("401", "Token Google invalido: client ID nao autorizado"));
+
+			var expiry = DateTimeOffset.FromUnixTimeSeconds(long.Parse(payload!.Exp));
+
+			if (expiry < DateTimeOffset.UtcNow)
+				return Result<LoginResponseDto>.Failure(new Error("401", "Token Google invalido ou expirado"));
+
+			var userResponse = await _userService.GetByEmailAsync(payload!.Email);
+
+			if (userResponse.IsFailure)
+				return Result<LoginResponseDto>.Failure(userResponse.Error);
+
+			var userResult = userResponse.Data!;
+
+			if (userResult.Blocked)
+				return Result<LoginResponseDto>.Failure(new Error("403", "Usuario bloqueado"));
+
+			return Result<LoginResponseDto>.Success(
+				new LoginResponseDto(
+					_tokenService.GenerateToken(userResult.UserName, userResult.Role),
+					_tokenService.GenerateRefreshToken(userResult.UserName)));
+		}
+		catch (Exception ex)
+		{
+			var error = new Error("500", ex.InnerException?.Message ?? ex.Message);
+			return Result<LoginResponseDto>.Failure(error);
+		}
+	}
+
+	public bool CanHandle(ELoginProvider loginProvider)
+		=> loginProvider == ELoginProvider.Google;
+}

--- a/XerifeTv.CMS/Shared/Extensions/ConfigureServices.cs
+++ b/XerifeTv.CMS/Shared/Extensions/ConfigureServices.cs
@@ -28,91 +28,93 @@ namespace XerifeTv.CMS.Shared.Extensions;
 
 public static class ConfigureServices
 {
-    public static IServiceCollection AddConfiguration(
-      this IServiceCollection services, IConfiguration _configuration)
-    {
-        services
-          .AddAuthAuthorization(_configuration)
-          .AddRepositories()
-          .AddServices()
-          .AddSwagger();
+	public static IServiceCollection AddConfiguration(
+	  this IServiceCollection services, IConfiguration _configuration)
+	{
+		services
+		  .AddAuthAuthorization(_configuration)
+		  .AddRepositories()
+		  .AddServices()
+		  .AddSwagger();
 
-        return services;
-    }
+		return services;
+	}
 
-    private static IServiceCollection AddRepositories(this IServiceCollection services)
-    {
-        services.AddScoped<IMovieRepository, MovieRepository>();
-        services.AddScoped<ISeriesRepository, SeriesRepository>();
-        services.AddScoped<IChannelRepository, ChannelRepository>();
-        services.AddScoped<IUserRepository, UserRepository>();
-        return services;
-    }
+	private static IServiceCollection AddRepositories(this IServiceCollection services)
+	{
+		services.AddScoped<IMovieRepository, MovieRepository>();
+		services.AddScoped<ISeriesRepository, SeriesRepository>();
+		services.AddScoped<IChannelRepository, ChannelRepository>();
+		services.AddScoped<IUserRepository, UserRepository>();
+		return services;
+	}
 
-    private static IServiceCollection AddServices(this IServiceCollection services)
-    {
-        services.AddScoped<IMovieService, MovieSevice>();
-        services.AddScoped<ISeriesService, SeriesService>();
-        services.AddScoped<IChannelService, ChannelService>();
-        services.AddScoped<IDashboardService, DashboardService>();
-        services.AddScoped<IContentService, ContentService>();
-        services.AddScoped<IUserService, UserService>();
-        services.AddScoped<ITokenService, TokenService>();
-        services.AddScoped<IAuthService, AuthService>();
-        services.AddScoped<ICacheService, CacheService>();
-        services.AddScoped<IStorageFilesService, StorageFilesService>();
-        services.AddScoped<ISpreadsheetReaderService, SpreadsheetReaderService>();
-        services.AddScoped<IHashPassword, HashPassword>();
-        services.AddScoped<IEmailService, EmailService>();
-        services.AddScoped<ISpreadsheetBatchImporter<IMovieService>, MoviesSpreadsheetImporter>();
-        services.AddScoped<ISpreadsheetBatchImporter<IChannelService>, ChannelsSpreadsheetImporter>();
+	private static IServiceCollection AddServices(this IServiceCollection services)
+	{
+		services.AddScoped<IMovieService, MovieSevice>();
+		services.AddScoped<ISeriesService, SeriesService>();
+		services.AddScoped<IChannelService, ChannelService>();
+		services.AddScoped<IDashboardService, DashboardService>();
+		services.AddScoped<IContentService, ContentService>();
+		services.AddScoped<IUserService, UserService>();
+		services.AddScoped<ITokenService, TokenService>();
+		services.AddScoped<IAuthService, AuthService>();
+		services.AddScoped<ICacheService, CacheService>();
+		services.AddScoped<IStorageFilesService, StorageFilesService>();
+		services.AddScoped<ISpreadsheetReaderService, SpreadsheetReaderService>();
+		services.AddScoped<IHashPassword, HashPassword>();
+		services.AddScoped<IEmailService, EmailService>();
+		services.AddScoped<ISpreadsheetBatchImporter<IMovieService>, MoviesSpreadsheetImporter>();
+		services.AddScoped<ISpreadsheetBatchImporter<IChannelService>, ChannelsSpreadsheetImporter>();
 		services.AddScoped<ISpreadsheetBatchImporter<ISeriesService>, SeriesSpreadsheetImporter>();
 		services.AddScoped<IEpisodesImporter, EpisodesImdbImporter>();
-        services.AddScoped<IImdbService, ImdbService>();
-        services.AddScoped<IBackgroundJobQueueRepository, BackgroundJobQueueRepository>();
-        services.AddScoped<IBackgroundJobQueueService, BackgroundJobQueueService>();
-        services.AddHostedService<BackgroundJobQueueWorker>();
-        return services;
-    }
+		services.AddScoped<IImdbService, ImdbService>();
+		services.AddScoped<IBackgroundJobQueueRepository, BackgroundJobQueueRepository>();
+		services.AddScoped<IBackgroundJobQueueService, BackgroundJobQueueService>();
+		services.AddScoped<ILoginStrategy, BasicLoginStrategy>();
+		services.AddScoped<ILoginStrategy, GoogleLoginStrategy>();
+		services.AddHostedService<BackgroundJobQueueWorker>();
+		return services;
+	}
 
-    private static IServiceCollection AddAuthAuthorization(
-      this IServiceCollection services, IConfiguration _configuration)
-    {
-        services.AddAuthentication(options =>
-        {
-            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-        })
-        .AddJwtBearer(options =>
-        {
-            options.TokenValidationParameters = TokenService.GetTokenValidationParameters(_configuration);
+	private static IServiceCollection AddAuthAuthorization(
+	  this IServiceCollection services, IConfiguration _configuration)
+	{
+		services.AddAuthentication(options =>
+		{
+			options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+			options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+		})
+		.AddJwtBearer(options =>
+		{
+			options.TokenValidationParameters = TokenService.GetTokenValidationParameters(_configuration);
 
-            options.Events = new JwtBearerEvents
-            {
-                OnMessageReceived = context =>
-            {
-                context.Token = context.Request.Cookies["Token"];
-                return Task.CompletedTask;
-            }
-            };
-        });
+			options.Events = new JwtBearerEvents
+			{
+				OnMessageReceived = context =>
+				{
+					context.Token = context.Request.Cookies["Token"];
+					return Task.CompletedTask;
+				}
+			};
+		});
 
-        services.AddAuthorization();
-        return services;
-    }
+		services.AddAuthorization();
+		return services;
+	}
 
-    public static IServiceCollection AddSwagger(this IServiceCollection services)
-    {
-        services.AddSwaggerGen(options =>
-        {
-            options.SwaggerDoc("v1", new OpenApiInfo
-            {
-                Version = "v1",
-                Title = "Content API",
-                Description = "content API documentation"
-            });
-        });
+	public static IServiceCollection AddSwagger(this IServiceCollection services)
+	{
+		services.AddSwaggerGen(options =>
+		{
+			options.SwaggerDoc("v1", new OpenApiInfo
+			{
+				Version = "v1",
+				Title = "Content API",
+				Description = "content API documentation"
+			});
+		});
 
-        return services;
-    }
+		return services;
+	}
 }

--- a/XerifeTv.CMS/Views/Shared/_Layout.cshtml
+++ b/XerifeTv.CMS/Views/Shared/_Layout.cshtml
@@ -47,6 +47,7 @@
   <script src="https://vjs.zencdn.net/8.20.0/video.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/videojs-hls-quality-selector/dist/videojs-hls-quality-selector.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://accounts.google.com/gsi/client"></script>
   <style>
     .side-menu .nav-link:not(.active):hover {
       background: #1e344f;

--- a/XerifeTv.CMS/Views/Users/SignIn.cshtml
+++ b/XerifeTv.CMS/Views/Users/SignIn.cshtml
@@ -1,4 +1,6 @@
-﻿@{
+﻿@using XerifeTv.CMS.Modules.Authentication.Enums
+
+@{
   ViewData["Title"] = "SignIn";
 }
 
@@ -22,9 +24,13 @@
 <div class="container d-flex flex-column justify-content-center align-items-center" style="height: 80vh;">
   
   <form 
+    id="signInForm"
     asp-controller="Users"
     asp-action="SignIn"
     class="w-50 p-4 py-5 signin-form position-relative">
+
+    <input type="hidden" id="provider" name="provider" value="@((int)ELoginProvider.Basic)" />
+    <input type="hidden" id="externalToken" name="externalToken" value="" />
 
     <div class="w-100 d-flex justify-content-center mb-5 py-1">
       <img src="~/assets/logo.png" alt="logo" style="width: 60%;"/>
@@ -61,6 +67,7 @@
     </div>
 
     <button type="submit" class="btn btn-primary w-100 mt-1">Login</button>
+    <div id="googleSignInDiv" class="mt-3"></div>
 
     <div 
       class="w-100 d-flex justify-content-center align-items-center position-absolute"
@@ -74,3 +81,32 @@
     </div>
   </form>
 </div>
+
+@section scripts {
+    <script>
+        function handleGoogleCredentialResponse(response) {
+            const idToken = response.credential;
+            $('#externalToken').val(idToken);
+            $('#provider').val(@((int)ELoginProvider.Google));
+
+            $('button').prop('disabled', true);
+            $('input').prop('readonly', true);
+            $('#signInForm').trigger('submit');
+        }
+
+        $(document).ready(function () {
+            google.accounts.id.initialize({
+                client_id: '@ViewBag.GoogleClientId',
+                callback: handleGoogleCredentialResponse
+            });
+
+            google.accounts.id.renderButton(
+                document.getElementById('googleSignInDiv'), { 
+                    theme: 'outline', 
+                    size: 'large',
+                    logo_alignment: 'left'
+                }
+            );
+        });
+    </script>
+}

--- a/XerifeTv.CMS/appsettings.json
+++ b/XerifeTv.CMS/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Hash": {
     "Salt": ""
-  }, 
+  },
   "Jwt": {
     "Key": "",
     "Issuer": "Xerifetvcms",
@@ -34,6 +34,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "OAuth2Google": {
+    "ClientId": ""
   },
   "baseUrl": "",
   "AllowedHosts": "*"


### PR DESCRIPTION
- Add ILoginStrategy interface to support multiple login types
- Implement GoogleLoginStrategy with idToken validation via GoogleJsonWebSignature
- Keep BasicLoginStrategy for traditional authentication
- Configure AuthService to select the correct strategy based on login type
- Adjust controller and frontend to support Google OAuth2 login
- Use Google Client ID from appsettings passed to the view