### PR TITLE
refactor: move caching responsibility out of services

### DIFF
--- a/XerifeTv.CMS/Controllers/ContentController.cs
+++ b/XerifeTv.CMS/Controllers/ContentController.cs
@@ -1,96 +1,180 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using XerifeTv.CMS.Modules.Content.Interfaces;
+using XerifeTv.CMS.Modules.Abstractions.Interfaces;
+using XerifeTv.CMS.Modules.Common;
 using XerifeTv.CMS.Modules.Common.Dtos;
 using XerifeTv.CMS.Modules.Content.Dtos.Request;
+using XerifeTv.CMS.Modules.Content.Dtos.Response;
+using XerifeTv.CMS.Modules.Content.Interfaces;
+using XerifeTv.CMS.Modules.Series;
 
 namespace XerifeTv.CMS.Controllers;
 
 [Route("Api/Content")]
 [ApiController]
-public class ContentController(IContentService _service, ILogger<ContentController> _logger) : ControllerBase
+public class ContentController(
+	IContentService _service, 
+	ILogger<ContentController> _logger,
+    ICacheService _cacheService) : ControllerBase
 {
 	[HttpGet]
 	[Route("Movies")]
 	public async Task<IActionResult> Movies(string categories = "", int? currentPage = 1, int? limit = 10)
 	{
-		var _dto = new GetGroupByCategoryRequestDto(
+		_logger.LogInformation("Request Content API /Movies");
+
+        var cacheKey = $"moviesGroupByCategory-{NormalizeCsv(categories)}-{currentPage}-{limit}";
+        var responseCache = _cacheService.GetValue<IEnumerable<ItemsByCategory<GetMovieContentResponseDto>>>(cacheKey);
+
+        if (responseCache != null) return Ok(responseCache);
+
+        var _dto = new GetGroupByCategoryRequestDto(
 		  [.. categories.Split(',').Select(x => x.Trim())],
 		  currentPage ?? 1,
 		  limit ?? 5);
 
 		var response = await _service.GetMoviesGroupByCategoryAsync(_dto);
-		_logger.LogInformation("Request Content API /Movies");
 
-		return Ok(response.IsSuccess ? response.Data : []);
+		if (response.IsFailure) return BadRequest();
+
+        _cacheService.SetValue(cacheKey, response.Data);
+
+        return Ok(response.Data);
 	}
 
 	[HttpGet]
 	[Route("Movies/{category}")]
 	public async Task<IActionResult> MoviesCategory(string category, int? currentPage, int? limit)
 	{
-		var response = await _service.GetMoviesByCategoryAsync(new GetContentsRequestDto(category, currentPage, limit));
-		_logger.LogInformation($"Request Content API /Movies/{category}");
+		_logger.LogInformation("Request Content API /Movies/{category}", category);
 
-		return Ok(response.IsSuccess ? response.Data : new object());
+        var cacheKey = $"moviesByCategory-{category}-{currentPage}-{limit}";
+        var responseCache = _cacheService.GetValue<PagedList<GetMovieContentResponseDto>>(cacheKey);
+
+		if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetMoviesByCategoryAsync(new GetContentsRequestDto(category, currentPage, limit));
+
+        if (response.IsFailure) return BadRequest();
+
+        _cacheService.SetValue(cacheKey, response.Data);
+
+        return Ok(response.Data);
 	}
 
 	[HttpGet]
 	[Route("Series")]
 	public async Task<IActionResult> Series(string categories = "", int? currentPage = 1, int? limit = 10)
 	{
-		var _dto = new GetGroupByCategoryRequestDto(
+		_logger.LogInformation("Request Content API /Series");
+
+        var cacheKey = $"seriesGroupByCategory-{NormalizeCsv(categories)}-{currentPage}-{limit}";
+        var responseCache = _cacheService.GetValue<IEnumerable<ItemsByCategory<GetSeriesContentResponseDto>>>(cacheKey);
+
+        if (responseCache != null) return Ok(responseCache);
+
+        var _dto = new GetGroupByCategoryRequestDto(
 		  [.. categories.Split(',').Select(x => x.Trim())],
 		  currentPage ?? 1,
 		  limit ?? 5);
 
 		var response = await _service.GetSeriesGroupByCategoryAsync(_dto);
-		_logger.LogInformation("Request Content API /Series");
 
-		return Ok(response.IsSuccess ? response.Data : []);
+        if (response.IsFailure) return BadRequest();
+
+        _cacheService.SetValue(cacheKey, response.Data);
+
+        return Ok(response.Data);
 	}
 
 	[HttpGet]
 	[Route("Series/{category}")]
 	public async Task<IActionResult> SeriesCategory(string category, int? currentPage, int? limit)
 	{
-		var response = await _service.GetSeriesByCategoryAsync(new GetContentsRequestDto(category, currentPage, limit));
-		_logger.LogInformation($"Request Content API /Series/{category}");
+		_logger.LogInformation("Request Content API /Series/{category}", category);
 
-		return Ok(response.IsSuccess ? response.Data : []);
+        var cacheKey = $"seriesGroupByCategory-{category}-{currentPage}-{limit}";
+        var responseCache = _cacheService.GetValue<IEnumerable<GetSeriesContentResponseDto>>(cacheKey);
+
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetSeriesByCategoryAsync(new GetContentsRequestDto(category, currentPage, limit));
+
+        if (response.IsFailure) return BadRequest();
+
+        _cacheService.SetValue(cacheKey, response.Data);
+
+        return Ok(response.Data);
 	}
 
 	[HttpGet]
 	[Route("Series/Episodes/{serieId}/{season}")]
 	public async Task<IActionResult> SeriesEpisodes(string serieId, int season)
 	{
-		var response = await _service.GetEpisodesSeriesBySeasonAsync(serieId, season);
-		_logger.LogInformation($"Request Content API /Series/Episodes/{serieId}/{season}");
+		_logger.LogInformation("Request Content API /Series/Episodes/{serieId}/{season}", serieId, season);
 
-		return Ok(response.IsSuccess ? response.Data : []);
+        var cacheKey = $"episodesSeriesBySeason-{serieId}-{season}";
+        var responseCache = _cacheService.GetValue<IEnumerable<Episode>>(cacheKey);
+
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetEpisodesSeriesBySeasonAsync(serieId, season);
+
+        if (response.IsFailure) return BadRequest();
+
+        _cacheService.SetValue(cacheKey, response.Data);
+
+        return Ok(response.Data);
 	}
 
 	[HttpGet]
 	[Route("Channels")]
 	public async Task<IActionResult> Channels(string categories = "", int? currentPage = 1, int? limit = 10)
 	{
-		var _dto = new GetGroupByCategoryRequestDto(
+		_logger.LogInformation("Request Content API /Channels");
+
+        var cacheKey = $"channelsGroupByCategory-{NormalizeCsv(categories)}-{currentPage}-{limit}";
+        var responseCache = _cacheService.GetValue<IEnumerable<ItemsByCategory<GetChannelContentResponseDto>>>(cacheKey);
+
+        if (responseCache != null) return Ok(responseCache);
+
+        var _dto = new GetGroupByCategoryRequestDto(
 		  [.. categories.Split(',').Select(x => x.Trim())],
 		  currentPage ?? 1,
 		  limit ?? 5);
 
 		var response = await _service.GetChannelsGroupByCategoryAsync(_dto);
-		_logger.LogInformation("Request Content API /Channels");
 
-		return Ok(response.IsSuccess ? response.Data : []);
+        if (response.IsFailure) return BadRequest();
+
+        _cacheService.SetValue(cacheKey, response.Data);
+
+        return Ok(response.Data);
 	}
 
 	[HttpGet]
 	[Route("Search/{title}")]
 	public async Task<IActionResult> ContentsByTitle(string title, int? currentPage, int? limit)
 	{
-		var response = await _service.GetContentsByTitleAsync(new GetContentsRequestDto(title, currentPage, limit));
-		_logger.LogInformation($"Request Content API /Search/{title}");
+		_logger.LogInformation("Request Content API /Search/{title}", title);
 
-		return Ok(response.IsSuccess ? response.Data : new object());
-	}
+        var cacheKey = $"contentsByTitle-{title}-{currentPage}-{limit}";
+		var responseCache = _cacheService.GetValue<GetContentsByNameResponseDto>(cacheKey);
+
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetContentsByTitleAsync(new(title, currentPage, limit));
+
+        if (response.IsFailure) return BadRequest();
+
+        _cacheService.SetValue(cacheKey, response.Data);
+
+        return Ok(response.Data);
+    }
+
+    private static string NormalizeCsv(string csv)
+        => string.Join(',',
+            csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+               .Select(x => x.ToLowerInvariant())
+               .OrderBy(x => x)
+        );
 }

--- a/XerifeTv.CMS/Modules/Content/Dtos/Response/GetChannelContentResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Content/Dtos/Response/GetChannelContentResponseDto.cs
@@ -14,7 +14,7 @@ public class GetChannelContentResponseDto
     public string? MediaRoute { get; private set; }
     public string? UrlResolverPath
         => !string.IsNullOrWhiteSpace(MediaDeliveryProfileId)
-            ? $"/MediaDeliveryProfiles/ResolveUrl?mediaDeliveryProfileId={MediaDeliveryProfileId}&mediaPath={Uri.EscapeDataString(MediaRoute ?? "")}"
+            ? $"/MediaDeliveryProfiles/ResolveUrl?mediaDeliveryProfileId={MediaDeliveryProfileId}&mediaPath={Uri.EscapeDataString(MediaRoute ?? "")}&isCached=true"
             : $"/MediaDeliveryProfiles/ResolveUrlFixed?urlFixed={Uri.EscapeDataString(Video?.Url ?? "")}&streamFormat={Video?.StreamFormat}";
 
     public static GetChannelContentResponseDto FromEntity(ChannelEntity entity)

--- a/XerifeTv.CMS/Modules/Content/Dtos/Response/GetMovieContentResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Content/Dtos/Response/GetMovieContentResponseDto.cs
@@ -21,7 +21,7 @@ public class GetMovieContentResponseDto
     public string DurationHHmm => DateTimeHelper.ConvertSecondsToHHmm(Video?.Duration ?? 0);
     public string? UrlResolverPath
         => !string.IsNullOrWhiteSpace(MediaDeliveryProfileId)
-            ? $"/MediaDeliveryProfiles/ResolveUrl?mediaDeliveryProfileId={MediaDeliveryProfileId}&mediaPath={Uri.EscapeDataString(MediaRoute ?? "")}"
+            ? $"/MediaDeliveryProfiles/ResolveUrl?mediaDeliveryProfileId={MediaDeliveryProfileId}&mediaPath={Uri.EscapeDataString(MediaRoute ?? "")}&isCached=true"
             : $"/MediaDeliveryProfiles/ResolveUrlFixed?urlFixed={Uri.EscapeDataString(Video?.Url ?? "")}&streamFormat={Video?.StreamFormat}";
 
     public static GetMovieContentResponseDto FromEntity(MovieEntity entity)

--- a/XerifeTv.CMS/Modules/Media/Delivery/Services/MediaDeliveryUrlResolver.cs
+++ b/XerifeTv.CMS/Modules/Media/Delivery/Services/MediaDeliveryUrlResolver.cs
@@ -1,5 +1,4 @@
-﻿using XerifeTv.CMS.Modules.Abstractions.Interfaces;
-using XerifeTv.CMS.Modules.Common;
+﻿using XerifeTv.CMS.Modules.Common;
 using XerifeTv.CMS.Modules.Media.Delivery.Dtos.Response;
 using XerifeTv.CMS.Modules.Media.Delivery.Intefaces;
 
@@ -7,20 +6,12 @@ namespace XerifeTv.CMS.Modules.Media.Delivery.Services;
 
 public class MediaDeliveryUrlResolver(
     IEnumerable<IMediaDeliveryTokenStrategy> _mediaTokenStrategies,
-    IMediaDeliveryProfileService _service,
-    ICacheService _cacheService) : IMediaDeliveryUrlResolver
+    IMediaDeliveryProfileService _service) : IMediaDeliveryUrlResolver
 {
     public async Task<Result<GetResolveUrlResponseDto>> ResolveUrlAsync(string mediaPath, string mediaDeliveryProfileId)
     {
         try
         {
-            var normalizedPath = mediaPath.Trim().ToLowerInvariant();
-            var cacheKey = $"resolve-url:{normalizedPath}:{mediaDeliveryProfileId}";
-            var responseCache = _cacheService.GetValue<GetResolveUrlResponseDto>(cacheKey);
-
-            if (responseCache != null)
-                return Result<GetResolveUrlResponseDto>.Success(responseCache);
-
             var response = await _service.GetAsync(mediaDeliveryProfileId);
 
             if (response.IsFailure)
@@ -47,10 +38,7 @@ public class MediaDeliveryUrlResolver(
                 Query = tokenResult.Data
             };
 
-            GetResolveUrlResponseDto resolvedUrl = new(urlBuilder.ToString(), mediaProfile.StreamFormat);
-            _cacheService.SetValue(cacheKey, resolvedUrl);
-
-            return Result<GetResolveUrlResponseDto>.Success(resolvedUrl);
+            return Result<GetResolveUrlResponseDto>.Success(new(urlBuilder.ToString(), mediaProfile.StreamFormat));
         }
         catch (Exception ex)
         {
@@ -61,6 +49,6 @@ public class MediaDeliveryUrlResolver(
 
     public async Task<Result<GetResolveUrlResponseDto>> ResolveUrlFixedAsync(string urlFixed, string streamFormat)
     {
-       return await Task.FromResult(Result<GetResolveUrlResponseDto>.Success(new(urlFixed, streamFormat)));
+        return await Task.FromResult(Result<GetResolveUrlResponseDto>.Success(new(urlFixed, streamFormat)));
     }
 }

--- a/XerifeTv.CMS/Shared/Extensions/ConfigureServices.cs
+++ b/XerifeTv.CMS/Shared/Extensions/ConfigureServices.cs
@@ -67,7 +67,7 @@ public static class ConfigureServices
 		services.AddScoped<IUserService, UserService>();
 		services.AddScoped<ITokenService, TokenService>();
 		services.AddScoped<IAuthService, AuthService>();
-		services.AddScoped<ICacheService, CacheService>();
+		services.AddSingleton<ICacheService, CacheService>();
 		services.AddScoped<IStorageFilesService, StorageFilesService>();
 		services.AddScoped<ISpreadsheetReaderService, SpreadsheetReaderService>();
 		services.AddScoped<IHashPassword, HashPassword>();


### PR DESCRIPTION
Removed cache logic from UrlResolverService and ContentApiService, keeping them focused on business logic only.
Caching is now handled at a higher layer.