### PR TITLE
feat(content-api): implement v2 endpoints replacing frontend mock contract

### DIFF
--- a/XerifeTv.CMS/Controllers/ContentAPI/Content.v1.Controller.cs
+++ b/XerifeTv.CMS/Controllers/ContentAPI/Content.v1.Controller.cs
@@ -7,13 +7,13 @@ using XerifeTv.CMS.Modules.Content.Dtos.Response;
 using XerifeTv.CMS.Modules.Content.Interfaces;
 using XerifeTv.CMS.Modules.Series;
 
-namespace XerifeTv.CMS.Controllers;
+namespace XerifeTv.CMS.Controllers.ContentAPI;
 
 [Route("Api/Content")]
 [ApiController]
-public class ContentController(
-	IContentService _service, 
-	ILogger<ContentController> _logger,
+public class ContentV1Controller(
+	IContentV1Service _service, 
+	ILogger<ContentV1Controller> _logger,
     ICacheService _cacheService) : ControllerBase
 {
 	[HttpGet]

--- a/XerifeTv.CMS/Controllers/ContentAPI/Content.v2.Controller.cs
+++ b/XerifeTv.CMS/Controllers/ContentAPI/Content.v2.Controller.cs
@@ -1,0 +1,345 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Collections;
+using XerifeTv.CMS.Modules.Abstractions.Interfaces;
+using XerifeTv.CMS.Modules.Content.Interfaces;
+using XerifeTv.CMS.Modules.Movie.Enums;
+using XerifeTv.CMS.Modules.Movie.Interfaces;
+using XerifeTv.CMS.Modules.Series.Enums;
+using XerifeTv.CMS.Modules.Series.Interfaces;
+
+namespace XerifeTv.CMS.Controllers.ContentAPI;
+
+[Route("Api/Content/v2")]
+[ApiController]
+public class ContentV2Controller(
+    IContentV2Service _service,
+    IMovieService _movieService,
+    ISeriesService _seriesService,
+    ILogger<ContentV2Controller> _logger,
+    ICacheService _cacheService) : ControllerBase
+{
+    [HttpGet]
+    [Route("movies")]
+    public async Task<IActionResult> Movies()
+    {
+        _logger.LogInformation("Request Content API v2 /movies");
+
+        var cacheKey = "content_v2_movies";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetMoviesAsync(200);
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("series")]
+    public async Task<IActionResult> Series()
+    {
+        _logger.LogInformation("Request Content API v2 /series");
+
+        var cacheKey = "content_v2_series";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetSeriesAsync(200);
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("movies/{id}")]
+    public async Task<IActionResult> MovieById(string id)
+    {
+        _logger.LogInformation("Request Content API v2 /movies/{id}", id);
+
+        var cacheKey = $"content_v2_movie_{id}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetMovieByIdAsync(id);
+
+        if (response.IsSuccess)
+        {
+            if (response.Data is null) return NotFound();
+
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("series/{id}")]
+    public async Task<IActionResult> SeriesById(string id)
+    {
+        _logger.LogInformation("Request Content API v2 /series/{id}", id);
+
+        var cacheKey = $"content_v2_series_{id}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetSeriesByIdAsync(id);
+
+        if (response.IsSuccess)
+        {
+            if (response.Data is null) return NotFound();
+
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("series/{seriesId}/seasons/{seasonNumber}/episodes")]
+    public async Task<IActionResult> EpisodesBySeriesIdAndSeason(string seriesId, int seasonNumber)
+    {
+        _logger.LogInformation("Request Content API v2 /series/{seriesId}/season/{seasonNumber}/episodes", seriesId, seasonNumber);
+
+        var cacheKey = $"content_v2_episodes_{seriesId}_{seasonNumber}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetEpisodesBySeriesIdAndSeasonAsync(seriesId, seasonNumber);
+
+        if (response.IsSuccess)
+        {
+            var result = new
+            {
+                seriesId,
+                seasonNumber,
+                episodes = response.Data
+            };
+
+            _cacheService.SetValue(cacheKey, result);
+            return Ok(result);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("movies/categories")]
+    public async Task<IActionResult> MoviesCategories()
+    {
+        _logger.LogInformation("Request Content API v2 /movies/categories");
+
+        var cacheKey = "content_v2_movies_categories";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetMoviesCategoriesAsync();
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("series/categories")]
+    public async Task<IActionResult> SeriesCategories()
+    {
+        _logger.LogInformation("Request Content API v2 /series/categories");
+
+        var cacheKey = "content_v2_series_categories";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetSeriesCategoriesAsync();
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("movies/category/{category}")]
+    public async Task<IActionResult> MoviesByCategory(string category, int page = 1, int pageSize = 10)
+    {
+        _logger.LogInformation("Request Content API v2 /movies/category/{category} page={page} pageSize={pageSize}", category, page, pageSize);
+
+        var norm = NormalizeCsv(category);
+        var cacheKey = $"content_v2_movies_by_category-{norm}-{page}-{pageSize}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetMoviesByCategoryAsync(category, page, pageSize);
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("series/category/{category}")]
+    public async Task<IActionResult> SeriesByCategory(string category, int page = 1, int pageSize = 10)
+    {
+        _logger.LogInformation("Request Content API v2 /series/category/{category} page={page} pageSize={pageSize}", category, page, pageSize);
+
+        var norm = NormalizeCsv(category);
+        var cacheKey = $"content_v2_series_by_category-{norm}-{page}-{pageSize}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetSeriesByCategoryAsync(category, page, pageSize);
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("movies/{movieId}/recommended")]
+    public async Task<IActionResult> MoviesRecommended(string movieId)
+    {
+        _logger.LogInformation("Request Content API v2 /movies/{movieId}/recommended", movieId);
+
+        var cacheKey = $"content_v2_movies_recommended_{movieId}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetMoviesRecommendedAsync(movieId);
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("search")]
+    public async Task<IActionResult> Search(string term)
+    {
+        _logger.LogInformation("Request Content API v2 /search term={term}", term);
+
+        var cacheKey = $"content_v2_search_{term}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var moviesResponse = await _service.GetMoviesByTermAsync(term, limit: 15);
+        var seriesResponse = await _service.GetSeriesByTermAsync(term, limit: 15);
+
+        if (moviesResponse.IsSuccess && seriesResponse.IsSuccess)
+        {
+            var result = new
+            {
+                movies = moviesResponse.Data,
+                series = seriesResponse.Data
+            };
+
+            _cacheService.SetValue(cacheKey, result);
+            return Ok(result);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("home")]
+    public async Task<IActionResult> Home()
+    {
+        _logger.LogInformation("Request Content API v2 /home");
+
+        var cacheKey = "content_v2_home";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var moviesCategoriesResponse = await _service.GetMoviesCategoriesAsync(5);
+        var seriesCategoriesResponse = await _service.GetSeriesCategoriesAsync(5);
+
+        if (moviesCategoriesResponse.IsSuccess && seriesCategoriesResponse.IsSuccess)
+        {
+            var random = new Random();
+            int randomValue = random.Next(1, 105);
+
+            string featuredType = "movie";
+            object? featuredContent = new();
+
+            if (randomValue % 2 == 0)
+            {
+                var moviesResponse = await _movieService.GetByFilterAsync(new(
+                    filter: EMovieSearchFilter.TITLE,
+                    order: EMovieOrderFilter.REGISTRATION_DATE_DESC,
+                    search: "",
+                    limitResults: 1,
+                    currentPage: 1,
+                    isIncludeDisabled: false));
+
+                if (moviesResponse.IsSuccess)
+                {
+                    featuredContent = moviesResponse.Data?.Items.FirstOrDefault();
+                }
+            }
+            else
+            {
+                var seriesResponse = await _seriesService.GetByFilterAsync(new(
+                    filter: ESeriesSearchFilter.TITLE,
+                    search: "a",
+                    limitResults: 25,
+                    currentPage: 1,
+                    isIncludeDisabled: false));
+
+                if (seriesResponse.IsSuccess)
+                {
+                    featuredType = "series";
+                    featuredContent = seriesResponse.Data?.Items.ToArray()[Random.Shared.Next(seriesResponse.Data?.Items.Count() ?? 0)];
+                }
+            }
+
+            var result = new
+            {
+                featured = featuredContent,
+                featuredType,
+                movieCategories = moviesCategoriesResponse.Data,
+                seriesCategories = seriesCategoriesResponse.Data
+            };
+
+            _cacheService.SetValue(cacheKey, result);
+            return Ok(result);
+        }
+
+        return BadRequest();
+    }
+
+    private static string NormalizeCsv(string csv)
+        => string.Join(',',
+            csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+               .Select(x => x.ToLowerInvariant())
+               .OrderBy(x => x)
+        );
+}

--- a/XerifeTv.CMS/Modules/Content/ContentV1Service.cs
+++ b/XerifeTv.CMS/Modules/Content/ContentV1Service.cs
@@ -16,10 +16,10 @@ using XerifeTv.CMS.Modules.Series.Interfaces;
 
 namespace XerifeTv.CMS.Modules.Content;
 
-public sealed class ContentService(
+public sealed class ContentV1Service(
   IMovieRepository _movieRepository,
   ISeriesRepository _seriesRepository,
-  IChannelRepository _channelRepository) : IContentService
+  IChannelRepository _channelRepository) : IContentV1Service
 {
     const int limitTotalResult = 50;
 

--- a/XerifeTv.CMS/Modules/Content/ContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/ContentV2Service.cs
@@ -1,0 +1,239 @@
+﻿using XerifeTv.CMS.Modules.Common;
+using XerifeTv.CMS.Modules.Content.Dtos.Response;
+using XerifeTv.CMS.Modules.Content.Interfaces;
+using XerifeTv.CMS.Modules.Movie.Enums;
+using XerifeTv.CMS.Modules.Movie.Interfaces;
+using XerifeTv.CMS.Modules.Series.Enums;
+using XerifeTv.CMS.Modules.Series.Interfaces;
+
+namespace XerifeTv.CMS.Modules.Content;
+
+public class ContentV2Service(
+    IMovieRepository _movieRepository,
+    ISeriesRepository _seriesRepository) : IContentV2Service
+{
+    public async Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesAsync(int limit)
+    {
+        try
+        {
+            var movies = await _movieRepository.GetAsync(currentPage: 1, limit);
+
+            return Result<IEnumerable<MovieContentV2ResponseDto>>.Success(movies.Items.Select(MovieContentV2ResponseDto.FromEntity));
+        }
+        catch (Exception ex)
+        {
+            return Result<IEnumerable<MovieContentV2ResponseDto>>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>> GetSeriesAsync(int limit)
+    {
+        try
+        {
+            var series = await _seriesRepository.GetAsync(currentPage: 1, limit);
+
+            return Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>.Success(series.Items.Select(SeriesSummaryContentV2ResponseDto.FromEntity));
+        }
+        catch (Exception ex)
+        {
+            return Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<MovieContentV2ResponseDto?>> GetMovieByIdAsync(string id)
+    {
+        try
+        {
+            var movie = await _movieRepository.GetAsync(id);
+
+            if (movie is null)
+                return Result<MovieContentV2ResponseDto?>.Failure(new("404", "Conteudo nao encontrado"));
+
+            return Result<MovieContentV2ResponseDto?>.Success(MovieContentV2ResponseDto.FromEntity(movie));
+        }
+        catch (Exception ex)
+        {
+            return Result<MovieContentV2ResponseDto?>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<SeriesSummaryContentV2ResponseDto?>> GetSeriesByIdAsync(string id)
+    {
+        try
+        {
+            var series = await _seriesRepository.GetAsync(id);
+
+            if (series is null)
+                return Result<SeriesSummaryContentV2ResponseDto?>.Failure(new("404", "Conteudo nao encontrado"));
+
+            return Result<SeriesSummaryContentV2ResponseDto?>.Success(SeriesSummaryContentV2ResponseDto.FromEntity(series));
+        }
+        catch (Exception ex)
+        {
+            return Result<SeriesSummaryContentV2ResponseDto?>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>> GetMoviesByCategoryAsync(string category, int page = 1, int pageSize = 1)
+    {
+        try
+        {
+            var movies = await _movieRepository.GetByFilterAsync(new(
+                filter: EMovieSearchFilter.CATEGORY,
+                order: EMovieOrderFilter.REGISTRATION_DATE_DESC,
+                search: category,
+                limitResults: pageSize,
+                currentPage: page,
+                isIncludeDisabled: false));
+
+            var moviesByCategory = movies.Items;
+
+            return Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>.Success(new(
+                currentPage: movies.CurrentPage,
+                totalPageCount: movies.TotalPageCount,
+                items: [new ItemsByCategory<MovieContentV2ResponseDto>(category, moviesByCategory.Select(MovieContentV2ResponseDto.FromEntity))]));
+        }
+        catch (Exception ex)
+        {
+            return Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>> GetSeriesByCategoryAsync(string category, int page = 1, int pageSize = 1)
+    {
+        try
+        {
+            var series = await _seriesRepository.GetByFilterAsync(new(
+                filter: ESeriesSearchFilter.CATEGORY,
+                search: category,
+                limitResults: pageSize,
+                currentPage: page,
+                isIncludeDisabled: false));
+
+            var seriesByCategory = series.Items;
+
+            return Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>.Success(new(
+                currentPage: series.CurrentPage,
+                totalPageCount: series.TotalPageCount,
+                items: [new ItemsByCategory<SeriesSummaryContentV2ResponseDto>(category, seriesByCategory.Select(SeriesSummaryContentV2ResponseDto.FromEntity))]));
+        }
+        catch (Exception ex)
+        {
+            return Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<IEnumerable<EpisodeContentV2ResponseDto>>> GetEpisodesBySeriesIdAndSeasonAsync(string seriesId, int seasonNumber)
+    {
+        try
+        {
+            var seriesResult = await _seriesRepository.GetEpisodesBySeasonAsync(seriesId, seasonNumber, false);
+
+            return Result<IEnumerable<EpisodeContentV2ResponseDto>>.Success(
+                seriesResult?.Episodes.Select(EpisodeContentV2ResponseDto.FromEntity) ?? []);
+        }
+        catch (Exception ex)
+        {
+            return Result<IEnumerable<EpisodeContentV2ResponseDto>>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<string[]>> GetMoviesCategoriesAsync(int limit = 10)
+    {
+        try
+        {
+            var moviesCategoriesResult = await _movieRepository.GetAllCategoriesAsync();
+            return Result<string[]>.Success([.. moviesCategoriesResult.Take(limit)]);
+        }
+        catch (Exception ex)
+        {
+            return Result<string[]>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<string[]>> GetSeriesCategoriesAsync(int limit = 10)
+    {
+        try
+        {
+            var seriesCategoriesResult = await _seriesRepository.GetAllCategoriesAsync();
+            return Result<string[]>.Success([.. seriesCategoriesResult.Take(limit)]);
+        }
+        catch (Exception ex)
+        {
+            return Result<string[]>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesRecommendedAsync(string movieId)
+    {
+        try
+        {
+            var movieResult = await _movieRepository.GetAsync(movieId);
+
+            if (movieResult is null)
+                return Result<IEnumerable<MovieContentV2ResponseDto>>.Failure(new("404", "Conteudo nao encontrado"));
+
+            List<MovieContentV2ResponseDto> recommededMoviesList = [];
+
+            foreach (var category in movieResult.Categories.Take(3))
+            {
+                var moviesByCategoryResult = await _movieRepository.GetByFilterAsync(new(
+                    filter: EMovieSearchFilter.CATEGORY,
+                    order: EMovieOrderFilter.REGISTRATION_DATE_DESC,
+                    search: category,
+                    limitResults: 15,
+                    currentPage: 1,
+                    isIncludeDisabled: false));
+
+                recommededMoviesList.AddRange(moviesByCategoryResult.Items.Select(MovieContentV2ResponseDto.FromEntity));
+            }
+
+            recommededMoviesList = [.. recommededMoviesList.OrderByDescending(x => x.RatingImdb).Take(15).Where(x => x.Id != movieId)];
+
+            return Result<IEnumerable<MovieContentV2ResponseDto>>.Success(recommededMoviesList.DistinctBy(x => x.Id));
+        }
+        catch (Exception ex)
+        {
+            return Result<IEnumerable<MovieContentV2ResponseDto>>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>> GetSeriesByTermAsync(string searchTerm, int limit = 10)
+    {
+        try
+        {
+            var seriesResult = await _seriesRepository.GetByFilterAsync(new(
+                filter: ESeriesSearchFilter.TITLE,
+                search: searchTerm,
+                limitResults: limit,
+                currentPage: 1,
+                isIncludeDisabled: false));
+
+            return Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>.Success(seriesResult.Items.Select(SeriesSummaryContentV2ResponseDto.FromEntity));
+        }
+        catch (Exception ex)
+        {
+            return Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesByTermAsync(string searchTerm, int limit = 10)
+    {
+        try
+        {
+            var moviesResult = await _movieRepository.GetByFilterAsync(new(
+                filter: EMovieSearchFilter.TITLE,
+                order: EMovieOrderFilter.TITLE,
+                search: searchTerm,
+                limitResults: limit,
+                currentPage: 1,
+                isIncludeDisabled: false));
+
+            return Result<IEnumerable<MovieContentV2ResponseDto>>.Success(moviesResult.Items.Select(MovieContentV2ResponseDto.FromEntity));
+        }
+        catch (Exception ex)
+        {
+            return Result<IEnumerable<MovieContentV2ResponseDto>>.Failure(new("500", ex.Message));
+        }
+    }
+}

--- a/XerifeTv.CMS/Modules/Content/Dtos/Response/EpisodeContentV2ResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Content/Dtos/Response/EpisodeContentV2ResponseDto.cs
@@ -1,0 +1,33 @@
+﻿using XerifeTv.CMS.Modules.Series;
+using XerifeTv.CMS.Shared.Helpers;
+
+namespace XerifeTv.CMS.Modules.Content.Dtos.Response;
+
+public class EpisodeContentV2ResponseDto
+{
+    public string Id { get; private set; } = string.Empty;
+    public string Title { get; private set; } = string.Empty;
+    public string BannerURL { get; private set; } = string.Empty;
+    public string Duration { get; private set; } = string.Empty;
+    public long DurationSeconds { get; private set; }
+    public string SubtitleURL { get; private set; } = string.Empty;
+    public string VideoResolverURL { get; private set; } = string.Empty;
+
+    public static EpisodeContentV2ResponseDto FromEntity(Episode entity)
+    {
+        string videoResolverPath = !string.IsNullOrWhiteSpace(entity.MediaDeliveryProfileId)
+            ? $"/ResolveUrl?mediaDeliveryProfileId={entity.MediaDeliveryProfileId}&mediaPath={Uri.EscapeDataString(entity.MediaRoute ?? "")}&isCached=true"
+            : $"/ResolveUrlFixed?urlFixed={Uri.EscapeDataString(entity.Video?.Url ?? "")}&streamFormat={entity.Video?.StreamFormat}&isCached=true";
+        
+        return new()
+        {
+            Id = entity.Id,
+            Title = entity.Title,
+            BannerURL = entity.BannerUrl,
+            Duration = DateTimeHelper.ConvertSecondsToHHmm(entity.Video?.Duration ?? 0),
+            DurationSeconds = entity.Video?.Duration ?? 0,
+            SubtitleURL = entity.Video?.Subtitle ?? string.Empty,
+            VideoResolverURL = $"/MediaDeliveryProfiles{videoResolverPath}"
+        };
+    }
+}

--- a/XerifeTv.CMS/Modules/Content/Dtos/Response/MovieContentV2ResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Content/Dtos/Response/MovieContentV2ResponseDto.cs
@@ -1,0 +1,45 @@
+﻿using XerifeTv.CMS.Modules.Movie;
+using XerifeTv.CMS.Shared.Helpers;
+
+namespace XerifeTv.CMS.Modules.Content.Dtos.Response;
+
+public class MovieContentV2ResponseDto
+{
+    public string Id { get; private set; } = string.Empty;
+    public string Title { get; private set; } = string.Empty;
+    public string[] Categories { get; private set; } = [];
+    public string PosterURL { get; private set; } = string.Empty;
+    public string BannerURL { get; private set; } = string.Empty;
+    public string ParentalRating { get; private set; } = string.Empty;
+    public int ReleaseYear { get; private set; }
+    public string Synopsis { get; private set; } = string.Empty;
+    public float RatingImdb { get; private set; }
+    public string Duration { get; private set; } = string.Empty;
+    public long DurationSeconds { get; private set; }
+    public string VideoResolverURL { get; private set; } = string.Empty;
+    public string? SubtitleURL { get; private set; }
+
+    public static MovieContentV2ResponseDto FromEntity(MovieEntity entity)
+    {
+        string videoResolverPath = !string.IsNullOrWhiteSpace(entity.MediaDeliveryProfileId)
+            ? $"/ResolveUrl?mediaDeliveryProfileId={entity.MediaDeliveryProfileId}&mediaPath={Uri.EscapeDataString(entity.MediaRoute ?? "")}&isCached=true"
+            : $"/ResolveUrlFixed?urlFixed={Uri.EscapeDataString(entity.Video?.Url ?? "")}&streamFormat={entity.Video?.StreamFormat}&isCached=true";
+
+        return new()
+        {
+            Id = entity.Id,
+            Title = entity.Title,
+            Categories = [.. entity.Categories],
+            PosterURL = entity.PosterUrl,
+            BannerURL = entity.BannerUrl,
+            ParentalRating = entity.ParentalRating == 0 ? "L" : entity.ParentalRating.ToString(),
+            ReleaseYear = entity.ReleaseYear,
+            Synopsis = entity.Synopsis,
+            RatingImdb = entity.Review,
+            Duration = DateTimeHelper.ConvertSecondsToHHmm(entity.Video?.Duration ?? 0),
+            DurationSeconds = entity.Video?.Duration ?? 0,
+            VideoResolverURL = $"/MediaDeliveryProfiles{videoResolverPath}",
+            SubtitleURL = entity.Video?.Subtitle
+        };
+    }
+}

--- a/XerifeTv.CMS/Modules/Content/Dtos/Response/SeriesSummaryContentV2ResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Content/Dtos/Response/SeriesSummaryContentV2ResponseDto.cs
@@ -1,0 +1,36 @@
+﻿using XerifeTv.CMS.Modules.Series;
+
+namespace XerifeTv.CMS.Modules.Content.Dtos.Response;
+
+public class SeriesSummaryContentV2ResponseDto
+{
+    public string Id { get; private set; } = string.Empty;
+    public string Title { get; private set; } = string.Empty;
+    public string[] Categories { get; private set; } = [];
+    public string PosterURL { get; private set; } = string.Empty;
+    public string BannerURL { get; private set; } = string.Empty;
+    public string ParentalRating { get; private set; } = string.Empty;
+    public int ReleaseYear { get; private set; }
+    public double RatingImdb { get; private set; }
+    public string Synopsis { get; private set; } = string.Empty;
+    public int TotalSeasons { get; private set; }
+    public bool HasSubtitles { get; private set; }
+
+    public static SeriesSummaryContentV2ResponseDto FromEntity(SeriesEntity entity)
+    {
+        return new()
+        {
+            Id = entity.Id,
+            Title = entity.Title,
+            Categories = [.. entity.Categories],
+            PosterURL = entity.PosterUrl,
+            BannerURL = entity.BannerUrl,
+            ParentalRating = entity.ParentalRating == 0 ? "L" : entity.ParentalRating.ToString(),
+            ReleaseYear = entity.ReleaseYear,
+            RatingImdb = entity.Review,
+            Synopsis = entity.Synopsis,
+            TotalSeasons = entity.NumberSeasons,
+            HasSubtitles = false
+        };
+    }
+}

--- a/XerifeTv.CMS/Modules/Content/Interfaces/IContentV1Service.cs
+++ b/XerifeTv.CMS/Modules/Content/Interfaces/IContentV1Service.cs
@@ -6,7 +6,7 @@ using XerifeTv.CMS.Modules.Series;
 
 namespace XerifeTv.CMS.Modules.Content.Interfaces;
 
-public interface IContentService
+public interface IContentV1Service
 {
   Task<Result<IEnumerable<ItemsByCategory<GetMovieContentResponseDto>>>> GetMoviesGroupByCategoryAsync(GetGroupByCategoryRequestDto dto);
   Task<Result<PagedList<GetMovieContentResponseDto>>> GetMoviesByCategoryAsync(GetContentsRequestDto dto);

--- a/XerifeTv.CMS/Modules/Content/Interfaces/IContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/Interfaces/IContentV2Service.cs
@@ -1,0 +1,20 @@
+﻿using XerifeTv.CMS.Modules.Common;
+using XerifeTv.CMS.Modules.Content.Dtos.Response;
+
+namespace XerifeTv.CMS.Modules.Content.Interfaces;
+
+public interface IContentV2Service
+{
+    Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesAsync(int limit);
+    Task<Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>> GetSeriesAsync(int limit);
+    Task<Result<MovieContentV2ResponseDto?>> GetMovieByIdAsync(string id);
+    Task<Result<SeriesSummaryContentV2ResponseDto?>> GetSeriesByIdAsync(string id);
+    Task<Result<IEnumerable<EpisodeContentV2ResponseDto>>> GetEpisodesBySeriesIdAndSeasonAsync(string seriesId, int seasonNumber);
+    Task<Result<string[]>> GetMoviesCategoriesAsync(int limit = 10);
+    Task<Result<string[]>> GetSeriesCategoriesAsync(int limit = 10);
+    Task<Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>> GetMoviesByCategoryAsync(string category, int page = 1, int pageSize = 1);
+    Task<Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>> GetSeriesByCategoryAsync(string category, int page = 1, int pageSize = 1);
+    Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesRecommendedAsync(string movieId);
+    Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesByTermAsync(string searchTerm, int limit = 10);
+    Task<Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>> GetSeriesByTermAsync(string searchTerm, int limit = 10);
+}

--- a/XerifeTv.CMS/Modules/Movie/Interfaces/IMovieRepository.cs
+++ b/XerifeTv.CMS/Modules/Movie/Interfaces/IMovieRepository.cs
@@ -11,4 +11,5 @@ public interface IMovieRepository : IBaseRepository<MovieEntity>
     Task<PagedList<MovieEntity>> GetByFilterAsync(GetMoviesByFilterRequestDto dto);
     Task<IEnumerable<ItemsByCategory<MovieEntity>>> GetGroupByCategoryAsync(GetGroupByCategoryRequestDto dto);
     Task<MovieEntity?> GetByImdbIdAsync(string imdbId);
+    Task<ICollection<string>> GetAllCategoriesAsync();
 }

--- a/XerifeTv.CMS/Modules/Movie/MovieRepository.cs
+++ b/XerifeTv.CMS/Modules/Movie/MovieRepository.cs
@@ -78,4 +78,15 @@ public sealed class MovieRepository(IOptions<DBSettings> options)
 
         return result;
     }
+
+    public async Task<ICollection<string>> GetAllCategoriesAsync()
+    {
+        var categories = await _collection
+            .DistinctAsync<string>("Categories", FilterDefinition<MovieEntity>.Empty);
+
+        var list = await categories.ToListAsync();
+
+        var rng = new Random(DateTime.UtcNow.DayOfYear);
+        return [.. list.OrderBy(x => rng.Next())];
+    }
 }

--- a/XerifeTv.CMS/Modules/Series/Interfaces/ISeriesRepository.cs
+++ b/XerifeTv.CMS/Modules/Series/Interfaces/ISeriesRepository.cs
@@ -14,4 +14,5 @@ public interface ISeriesRepository : IBaseRepository<SeriesEntity>
     Task UpdateEpisodeAsync(string serieId, Episode episode);
     Task<bool> DeleteEpisodeAsync(string serieId, string episodeId);
     Task<SeriesEntity?> GetByImdbIdAsync(string imdbId);
+    Task<ICollection<string>> GetAllCategoriesAsync();
 }

--- a/XerifeTv.CMS/Modules/Series/SeriesRepository.cs
+++ b/XerifeTv.CMS/Modules/Series/SeriesRepository.cs
@@ -177,4 +177,15 @@ public sealed class SeriesRepository(IOptions<DBSettings> options)
 
         return response.ModifiedCount > 0;
     }
+
+    public async Task<ICollection<string>> GetAllCategoriesAsync()
+    {
+        var categories = await _collection
+            .DistinctAsync<string>("Categories", FilterDefinition<SeriesEntity>.Empty);
+
+        var list = await categories.ToListAsync();
+
+        var rng = new Random(DateTime.UtcNow.DayOfYear);
+        return [.. list.OrderBy(x => rng.Next())];
+    }
 }

--- a/XerifeTv.CMS/Shared/Extensions/ConfigureServices.cs
+++ b/XerifeTv.CMS/Shared/Extensions/ConfigureServices.cs
@@ -63,8 +63,9 @@ public static class ConfigureServices
 		services.AddScoped<ISeriesService, SeriesService>();
 		services.AddScoped<IChannelService, ChannelService>();
 		services.AddScoped<IDashboardService, DashboardService>();
-		services.AddScoped<IContentService, ContentService>();
-		services.AddScoped<IUserService, UserService>();
+		services.AddScoped<IContentV1Service, ContentV1Service>();
+        services.AddScoped<IContentV2Service, ContentV2Service>();
+        services.AddScoped<IUserService, UserService>();
 		services.AddScoped<ITokenService, TokenService>();
 		services.AddScoped<IAuthService, AuthService>();
 		services.AddSingleton<ICacheService, CacheService>();


### PR DESCRIPTION
## Purpose

This PR introduces **Content API v2**, replacing the previous MockAPI contract used by the web frontend.

The objective is to expose real CMS data following exactly the structure currently consumed by the frontend (`js/api.js`), enabling the removal of mocked data and allowing the web application to consume production-ready endpoints.

---

## Overview

A new version of the Content API was implemented to strictly align with the documented frontend contract. This includes:

- New DTOs for v2
- New controller(s) for versioned endpoints
- Explicit separation between Movie, SeriesSummary and Episode models
- Resolver endpoints for streaming playback

The implementation ensures full compatibility with frontend expectations.

---

## Implemented Endpoints

### Movies

- GET /movies
- GET /movies/{id}
- GET /movies/categories
- GET /movies/category/{category}?page=1&pageSize=16
- GET /movies/{movieId}/recommended

### Series

- GET /series
- GET /series/{id}
- GET /series/categories
- GET /series/category/{category}?page=1&pageSize=16
- GET /series/{seriesId}/seasons/{seasonNumber}/episodes

### Global

- GET /search?term={text}
- GET /home

---

## Contract Alignment

The API strictly follows frontend requirements.

Pagination format:

    {
      "pageSize": 16,
      "currentPage": 1,
      "totalPageCount": 4,
      "data": [],
      "hasPrevious": false,
      "hasNext": true
    }

Series details endpoint does NOT return episodes.

Subtitles are returned only in:
- Movie.subtitleURL
- Episode.subtitleURL

Video playback uses resolver endpoints returning:

    {
      "url": "https://example.com/stream.m3u8",
      "streamFormat": "HLS"
    }

Supported stream formats:
- MP4
- HLS
- DASH

Error response pattern:

    {
      "message": "Not found",
      "code": "NOT_FOUND"
    }

Suggested status codes:
- 400 for invalid parameters
- 404 for missing resources
- 500 for internal errors

---

## Architectural Notes

- Introduced a dedicated DTO layer for Content API v2
- Mapped CMS entities to frontend-aligned response models
- Separated summary vs detailed models (e.g., SeriesSummary)
- Maintained clear boundary between content metadata and playback resolution

---

## Impact

- Enables removal of MockAPI from the frontend
- Web application now consumes real CMS data
- No breaking changes to existing Content API v1 (if still maintained)