### PR TITLE
refactor: categories and home page of Content API v2

### DIFF
--- a/XerifeTv.CMS/Modules/Common/Dtos/CategoryCountDto.cs
+++ b/XerifeTv.CMS/Modules/Common/Dtos/CategoryCountDto.cs
@@ -1,0 +1,7 @@
+﻿namespace XerifeTv.CMS.Modules.Common.Dtos;
+
+public class CategoryCountDto
+{
+    public string Category { get; set; } = default!;
+    public int Count { get; set; }
+}

--- a/XerifeTv.CMS/Modules/Content/Dtos/Response/GetHomeContentV2ResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Content/Dtos/Response/GetHomeContentV2ResponseDto.cs
@@ -1,0 +1,15 @@
+﻿namespace XerifeTv.CMS.Modules.Content.Dtos.Response;
+
+public class GetHomeContentV2ResponseDto
+{
+    public object? FeaturedContent { get; set; }
+    public EFeaturedContentType FeaturedContentType { get; set; }
+    public string[] MovieCategores { get; set; } = [];
+    public string[] SeriesCategores { get; set; } = [];
+}
+
+public enum EFeaturedContentType
+{
+    MOVIE,
+    SERIES
+}

--- a/XerifeTv.CMS/Modules/Content/Interfaces/IContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/Interfaces/IContentV2Service.cs
@@ -17,4 +17,5 @@ public interface IContentV2Service
     Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesRecommendedAsync(string movieId);
     Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesByTermAsync(string searchTerm, int limit = 10);
     Task<Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>> GetSeriesByTermAsync(string searchTerm, int limit = 10);
+    Task<Result<GetHomeContentV2ResponseDto>> GetHomeContentAsync();
 }

--- a/XerifeTv.CMS/Modules/Movie/Interfaces/IMovieRepository.cs
+++ b/XerifeTv.CMS/Modules/Movie/Interfaces/IMovieRepository.cs
@@ -11,5 +11,5 @@ public interface IMovieRepository : IBaseRepository<MovieEntity>
     Task<PagedList<MovieEntity>> GetByFilterAsync(GetMoviesByFilterRequestDto dto);
     Task<IEnumerable<ItemsByCategory<MovieEntity>>> GetGroupByCategoryAsync(GetGroupByCategoryRequestDto dto);
     Task<MovieEntity?> GetByImdbIdAsync(string imdbId);
-    Task<ICollection<string>> GetAllCategoriesAsync();
+    Task<ICollection<CategoryCountDto>> GetCategoriesWithCountAsync();
 }

--- a/XerifeTv.CMS/Modules/Series/Interfaces/ISeriesRepository.cs
+++ b/XerifeTv.CMS/Modules/Series/Interfaces/ISeriesRepository.cs
@@ -14,5 +14,5 @@ public interface ISeriesRepository : IBaseRepository<SeriesEntity>
     Task UpdateEpisodeAsync(string serieId, Episode episode);
     Task<bool> DeleteEpisodeAsync(string serieId, string episodeId);
     Task<SeriesEntity?> GetByImdbIdAsync(string imdbId);
-    Task<ICollection<string>> GetAllCategoriesAsync();
+    Task<ICollection<CategoryCountDto>> GetCategoriesWithCountAsync();
 }


### PR DESCRIPTION
Refactors the search for movie and series categories to use aggregation in MongoDB, returning only the most relevant categories (>=10 items). Replaces old methods with GetCategoriesWithCountAsync and creates the CategoryCountDto DTO. Centralizes the home page logic in GetHomeContentAsync, standardizing the response with GetHomeContentV2ResponseDto and simplifying the controller. Adjusts repository and service interfaces according to the new subscriptions.