### PR TITLE
feat: new endpoints for searching across multiple categories

### DIFF
--- a/XerifeTv.CMS/Controllers/ContentAPI/Content.v2.Controller.cs
+++ b/XerifeTv.CMS/Controllers/ContentAPI/Content.v2.Controller.cs
@@ -138,7 +138,7 @@ public class ContentV2Controller(
         var responseCache = _cacheService.GetValue<object>(cacheKey);
         if (responseCache != null) return Ok(responseCache);
 
-        var response = await _service.GetMoviesCategoriesAsync();
+        var response = await _service.GetMoviesCategoriesAsync(12);
 
         if (response.IsSuccess)
         {
@@ -159,7 +159,7 @@ public class ContentV2Controller(
         var responseCache = _cacheService.GetValue<object>(cacheKey);
         if (responseCache != null) return Ok(responseCache);
 
-        var response = await _service.GetSeriesCategoriesAsync();
+        var response = await _service.GetSeriesCategoriesAsync(12);
 
         if (response.IsSuccess)
         {
@@ -287,6 +287,50 @@ public class ContentV2Controller(
 
             _cacheService.SetValue(cacheKey, result);
             return Ok(result);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("movies/categories/groups")]
+    public async Task<IActionResult> MoviesByCategories([FromQuery] List<string> categories, int page = 1, int pageSize = 10)
+    {
+        _logger.LogInformation("Request Content API v2 /movies/categories/groups categories={categories}", string.Join(", ", categories));
+
+        var norm = NormalizeCsv(string.Join('_', categories));
+        var cacheKey = $"content_v2_movies_by_categories-{norm}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetMoviesByCategoriesListAsync(categories, page, pageSize);
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
+        }
+
+        return BadRequest();
+    }
+
+    [HttpGet]
+    [Route("series/categories/groups")]
+    public async Task<IActionResult> SeriesByCategories([FromQuery] List<string> categories, int page = 1, int pageSize = 10)
+    {
+        _logger.LogInformation("Request Content API v2 /series/categories/groups categories={categories}", string.Join(", ", categories));
+
+        var norm = NormalizeCsv(string.Join('_', categories));
+        var cacheKey = $"content_v2_series_by_categories-{norm}";
+        var responseCache = _cacheService.GetValue<object>(cacheKey);
+        if (responseCache != null) return Ok(responseCache);
+
+        var response = await _service.GetSeriesByCategoriesListAsync(categories, page, pageSize);
+
+        if (response.IsSuccess)
+        {
+            _cacheService.SetValue(cacheKey, response.Data);
+            return Ok(response.Data);
         }
 
         return BadRequest();

--- a/XerifeTv.CMS/Modules/Content/ContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/ContentV2Service.cs
@@ -138,7 +138,7 @@ public class ContentV2Service(
 
             return Result<IEnumerable<EpisodeContentV2ResponseDto>>.Success(
                 seriesResult?.Episodes.Select(
-                    i =>  EpisodeContentV2ResponseDto.FromEntity(i, _configuration["SecuritySettings:ContentEncryptionKey"]!)) ?? []);
+                    i => EpisodeContentV2ResponseDto.FromEntity(i, _configuration["SecuritySettings:ContentEncryptionKey"]!)) ?? []);
         }
         catch (Exception ex)
         {
@@ -296,6 +296,50 @@ public class ContentV2Service(
         catch (Exception ex)
         {
             return Result<GetHomeContentV2ResponseDto>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>> GetMoviesByCategoriesListAsync(
+        List<string> categories,
+        int page,
+        int pageSize = 1)
+    {
+        try
+        {
+            var moviesByCategories = await _movieRepository.GetGroupByCategoryAsync(new(categories, page, pageSize));
+
+            return Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>.Success(new(
+                currentPage: page,
+                totalPageCount: moviesByCategories.Count(),
+                items: moviesByCategories.Select(c => new ItemsByCategory<MovieContentV2ResponseDto>(
+                    c.Category,
+                    c.Items.Select(i => MovieContentV2ResponseDto.FromEntity(i, _configuration["SecuritySettings:ContentEncryptionKey"]!))))));
+        }
+        catch (Exception ex)
+        {
+            return Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>.Failure(new("500", ex.Message));
+        }
+    }
+
+    public async Task<Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>> GetSeriesByCategoriesListAsync(
+        List<string> categories,
+        int page,
+        int pageSize = 1)
+    {
+        try
+        {
+            var seriesByCategories = await _seriesRepository.GetGroupByCategoryAsync(new(categories, page, pageSize));
+
+            return Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>.Success(new(
+                currentPage: page,
+                totalPageCount: seriesByCategories.Count(),
+                items: seriesByCategories.Select(c => new ItemsByCategory<SeriesSummaryContentV2ResponseDto>(
+                    c.Category,
+                    c.Items.Select(SeriesSummaryContentV2ResponseDto.FromEntity)))));
+        }
+        catch (Exception ex)
+        {
+            return Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>.Failure(new("500", ex.Message));
         }
     }
 }

--- a/XerifeTv.CMS/Modules/Content/Interfaces/IContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/Interfaces/IContentV2Service.cs
@@ -18,4 +18,6 @@ public interface IContentV2Service
     Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesByTermAsync(string searchTerm, int limit = 10);
     Task<Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>> GetSeriesByTermAsync(string searchTerm, int limit = 10);
     Task<Result<GetHomeContentV2ResponseDto>> GetHomeContentAsync();
+    Task<Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>> GetMoviesByCategoriesListAsync(List<string> categories, int page, int pageSize = 1);
+    Task<Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>> GetSeriesByCategoriesListAsync(List<string> categories, int page, int pageSize = 1);
 }


### PR DESCRIPTION
Endpoints have been added for movies and series grouped by multiple categories, with pagination and caching support. Service methods and interface have been updated to support these searches. A limit parameter has been added to category searches. A utility function for category normalization has been implemented.