### PR TITLE
refactor(search): allow unlimited results in franchise queries when limit is zero

### DIFF
--- a/XerifeTv.CMS/Modules/Movie/MovieRepository.cs
+++ b/XerifeTv.CMS/Modules/Movie/MovieRepository.cs
@@ -123,7 +123,7 @@ public sealed class MovieRepository(IOptions<DBSettings> options)
 
         if (!string.IsNullOrEmpty(movie.FranchiseId))
         {
-            var franchiseMovies = await GetMoviesByFranchiseIdAsync(movie.FranchiseId, limit, movie.Id);
+            var franchiseMovies = await GetMoviesByFranchiseIdAsync(movie.FranchiseId, limit: 0, movie.Id);
             int baseYear = movie.ReleaseYear;
 
             var franchiseMoviesOrdered = franchiseMovies?
@@ -194,7 +194,7 @@ public sealed class MovieRepository(IOptions<DBSettings> options)
         return await _collection
             .Find(r => r.FranchiseId == franchiseId && !r.Disabled && (movieIdIgnore == null || r.Id != movieIdIgnore))
             .SortBy(x => x.ReleaseYear)
-            .Limit(limit)
+            .Limit(limit > 0 ? limit : null)
             .ToListAsync();
     }
 

--- a/XerifeTv.CMS/Modules/Series/SeriesRepository.cs
+++ b/XerifeTv.CMS/Modules/Series/SeriesRepository.cs
@@ -226,7 +226,7 @@ public sealed class SeriesRepository(IOptions<DBSettings> options)
 
         if (!string.IsNullOrEmpty(series.FranchiseId))
         {
-            var franchiseSeries = await GetSeriesByFranchiseIdAsync(series.FranchiseId, limit, series.Id);
+            var franchiseSeries = await GetSeriesByFranchiseIdAsync(series.FranchiseId, limit: 0, series.Id);
             int baseYear = series.ReleaseYear;
 
             var franchiseSeriesOrdered = franchiseSeries?
@@ -297,7 +297,7 @@ public sealed class SeriesRepository(IOptions<DBSettings> options)
         return await _collection
             .Find(r => r.FranchiseId == franchiseId && !r.Disabled && (seriesIdIgnore == null || r.Id != seriesIdIgnore))
             .SortBy(x => x.ReleaseYear)
-            .Limit(limit)
+            .Limit(limit > 0 ? limit : null)
             .ToListAsync();
     }
 


### PR DESCRIPTION
- Update franchise search logic to treat limit=0 as a request for all records.
- Apply the .Limit() method conditionally only when the limit value is greater than zero.
- Remove unnecessary restrictions on movie and series result sets.