### PR TITLE
refactor(franchise): optimize search performance and loading logic

### DIFF
--- a/XerifeTv.CMS/Controllers/FranchisesController.cs
+++ b/XerifeTv.CMS/Controllers/FranchisesController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using XerifeTv.CMS.Modules.Franchise.Dtos.Response;
 using XerifeTv.CMS.Modules.Franchise.Dtos.Request;
 using XerifeTv.CMS.Modules.Franchise.Interfaces;
 
@@ -13,6 +14,9 @@ public class FranchisesController(
     [HttpGet]
     public async Task<IActionResult> Search(string? term)
     {
+        if (string.IsNullOrWhiteSpace(term) || term.Trim().Length < 2)
+            return Ok(Enumerable.Empty<GetFranchiseResponseDto>());
+
         var response = await _service.SearchByNameAsync(term ?? string.Empty);
 
         if (response.IsFailure)

--- a/XerifeTv.CMS/Controllers/MoviesController.cs
+++ b/XerifeTv.CMS/Controllers/MoviesController.cs
@@ -75,9 +75,6 @@ public class MoviesController(
         var mediaProfilesResponse = await _mediaDeliveryProfileService.GetAllAsync(isIncludeDisabled: false);
         if (mediaProfilesResponse.IsSuccess) mediaDeliveryProfiles = mediaProfilesResponse.Data ?? [];
 
-        var franchisesResponse = await _franchiseService.GetAllAsync();
-        if (franchisesResponse.IsSuccess) franchises = franchisesResponse.Data ?? [];
-
         if (id is not null)
         {
             var response = await _service.GetAsync(id);
@@ -86,7 +83,11 @@ public class MoviesController(
                 if (!string.IsNullOrWhiteSpace(response.Data?.FranchiseId))
                 {
                     var franchiseResponse = await _franchiseService.GetAsync(response.Data.FranchiseId);
-                    if (franchiseResponse.IsSuccess) selectedFranchiseName = franchiseResponse.Data?.Name;
+                    if (franchiseResponse.IsSuccess && franchiseResponse.Data is not null)
+                    {
+                        selectedFranchiseName = franchiseResponse.Data.Name;
+                        franchises = [franchiseResponse.Data];
+                    }
                 }
 
                 return View(new MovieFormModelView(response.Data, mediaDeliveryProfiles, franchises, selectedFranchiseName));

--- a/XerifeTv.CMS/Controllers/SeriesController.cs
+++ b/XerifeTv.CMS/Controllers/SeriesController.cs
@@ -71,9 +71,6 @@ public class SeriesController(
         IEnumerable<GetFranchiseResponseDto> franchises = [];
         string? selectedFranchiseName = null;
 
-        var franchisesResponse = await _franchiseService.GetAllAsync();
-        if (franchisesResponse.IsSuccess) franchises = franchisesResponse.Data ?? [];
-
 		if (id is not null)
 		{
 			var response = await _service.GetAsync(id);
@@ -82,7 +79,11 @@ public class SeriesController(
                 if (!string.IsNullOrWhiteSpace(response.Data?.FranchiseId))
                 {
                     var franchiseResponse = await _franchiseService.GetAsync(response.Data.FranchiseId);
-                    if (franchiseResponse.IsSuccess) selectedFranchiseName = franchiseResponse.Data?.Name;
+                    if (franchiseResponse.IsSuccess && franchiseResponse.Data is not null)
+                    {
+                        selectedFranchiseName = franchiseResponse.Data.Name;
+                        franchises = [franchiseResponse.Data];
+                    }
                 }
 
                 return View(new SeriesFormModelView(response.Data, franchises, selectedFranchiseName));

--- a/XerifeTv.CMS/Modules/Franchise/FranchiseRepository.cs
+++ b/XerifeTv.CMS/Modules/Franchise/FranchiseRepository.cs
@@ -20,10 +20,14 @@ public sealed class FranchiseRepository(IOptions<DBSettings> options)
     public async Task<IEnumerable<Franchise>> SearchByNameAsync(string search)
     {
         if (string.IsNullOrWhiteSpace(search))
-            return await GetAllAsync();
+            return [];
+
+        var normalizedSearch = search.Trim();
+        if (normalizedSearch.Length < 2)
+            return [];
 
         return await _collection
-            .Find(r => r.Name.Contains(search, StringComparison.CurrentCultureIgnoreCase))
+            .Find(r => r.Name.Contains(normalizedSearch, StringComparison.CurrentCultureIgnoreCase))
             .SortBy(r => r.Name)
             .Limit(20)
             .ToListAsync();

--- a/XerifeTv.CMS/Views/Shared/_FranchiseField.cshtml
+++ b/XerifeTv.CMS/Views/Shared/_FranchiseField.cshtml
@@ -109,6 +109,10 @@
         const franchiseOpenModalIcon = document.getElementById(`${prefix}_franchiseOpenModalIcon`);
         const franchiseModalElement = document.getElementById(`${prefix}_franchiseModal`);
         const franchiseModalLabel = document.getElementById(`${prefix}_franchiseModalLabel`);
+        const minSearchLength = 2;
+        const searchDebounceInMs = 250;
+        let searchTimeoutId = null;
+        let latestSearchRequest = 0;
 
         function findOptionByName(name) {
             return Array.from(franchiseList.options)
@@ -203,13 +207,29 @@
             existingOption?.remove();
         }
 
+        function clearSearchResults() {
+            franchiseList.innerHTML = '';
+        }
+
         async function loadFranchises(search) {
+            const normalizedSearch = (search || '').trim();
+            if (normalizedSearch.length < minSearchLength) {
+                latestSearchRequest += 1;
+                clearSearchResults();
+                syncSelectedFranchise();
+                return;
+            }
+
+            const requestId = ++latestSearchRequest;
+
             try {
                 const response = await $.ajax({
                     url: '/Franchises/Search',
                     method: 'GET',
-                    data: { term: search }
+                    data: { term: normalizedSearch }
                 });
+
+                if (requestId !== latestSearchRequest) return;
 
                 franchiseList.innerHTML = (response || []).map(franchise =>
                     `<option value="${franchise.name}" data-id="${franchise.id}"></option>`
@@ -224,7 +244,15 @@
         updateOpenModalButtonIcon();
 
         franchiseNameInput.addEventListener('input', function () {
-            loadFranchises(this.value);
+            const search = this.value;
+
+            if (searchTimeoutId) {
+                window.clearTimeout(searchTimeoutId);
+            }
+
+            searchTimeoutId = window.setTimeout(function () {
+                loadFranchises(search);
+            }, searchDebounceInMs);
         });
 
         franchiseNameInput.addEventListener('blur', syncSelectedFranchise);


### PR DESCRIPTION
- Require a minimum of 2 characters for franchise searches on both BE and FE.
- Implement 250ms debounce and request order control to prevent race conditions.
- Optimize edit views to load only the currently selected franchise by default.
- Add JS utility functions to clear results and synchronize UI selection.
- Reduce unnecessary requests to improve overall application responsiveness.