### PR TITLE
feat: adjust category limits and distribute movie/series categories

### DIFF
--- a/XerifeTv.CMS/Controllers/ContentAPI/Content.v2.Controller.cs
+++ b/XerifeTv.CMS/Controllers/ContentAPI/Content.v2.Controller.cs
@@ -145,7 +145,7 @@ public class ContentV2Controller(
         var responseCache = _cacheService.GetValue<object>(cacheKey);
         if (responseCache != null) return Ok(responseCache);
 
-        var response = await _service.GetMoviesCategoriesAsync(12);
+        var response = await _service.GetMoviesCategoriesAsync(15);
 
         if (response.IsSuccess)
         {
@@ -166,7 +166,7 @@ public class ContentV2Controller(
         var responseCache = _cacheService.GetValue<object>(cacheKey);
         if (responseCache != null) return Ok(responseCache);
 
-        var response = await _service.GetSeriesCategoriesAsync(12);
+        var response = await _service.GetSeriesCategoriesAsync(15);
 
         if (response.IsSuccess)
         {

--- a/XerifeTv.CMS/Modules/Content/CategoryDistributor.cs
+++ b/XerifeTv.CMS/Modules/Content/CategoryDistributor.cs
@@ -1,0 +1,89 @@
+﻿using XerifeTv.CMS.Modules.Abstractions.Entities;
+using XerifeTv.CMS.Modules.Common;
+using XerifeTv.CMS.Modules.Movie;
+
+namespace XerifeTv.CMS.Modules.Content;
+
+public static class CategoryDistributor
+{
+    public static IEnumerable<ItemsByCategory<T>> SpreadCategories<T>(IEnumerable<ItemsByCategory<T>> categories) where T : BaseEntity
+    {
+        if (categories.Count() <= 1)
+            return [.. categories];
+
+        var categoryItemSets = categories.ToDictionary(
+            c => c.Category,
+            c => c.Items
+                .Select(x => x.Id)
+                .ToHashSet());
+
+        var similarityMatrix = new Dictionary<string, Dictionary<string, int>>();
+
+        foreach (var categoryA in categories)
+        {
+            similarityMatrix[categoryA.Category] = [];
+
+            foreach (var categoryB in categories)
+            {
+                if (categoryA.Category == categoryB.Category)
+                    continue;
+
+                var setA = categoryItemSets[categoryA.Category];
+                var setB = categoryItemSets[categoryB.Category];
+
+                var smaller = setA.Count < setB.Count ? setA : setB;
+                var larger = setA.Count < setB.Count ? setB : setA;
+
+                int commonCount = 0;
+
+                foreach (var item in smaller)
+                {
+                    if (larger.Contains(item))
+                        commonCount++;
+                }
+
+                similarityMatrix[categoryA.Category][categoryB.Category] = commonCount;
+            }
+        }
+
+        var remaining = categories.ToList();
+        var result = new List<ItemsByCategory<T>>();
+
+        var start = categories
+            .OrderByDescending(c =>
+                similarityMatrix[c.Category].Values.Sum())
+            .First();
+
+        result.Add(start);
+        remaining.Remove(start);
+
+        while (remaining.Count > 0)
+        {
+            ItemsByCategory<T>? bestCandidate = null;
+
+            int bestScore = int.MaxValue;
+
+            foreach (var candidate in remaining)
+            {
+                int score = 0;
+
+                foreach (var selected in result)
+                {
+                    score += similarityMatrix[candidate.Category]
+                        .GetValueOrDefault(selected.Category);
+                }
+
+                if (score < bestScore)
+                {
+                    bestScore = score;
+                    bestCandidate = candidate;
+                }
+            }
+
+            result.Add(bestCandidate!);
+            remaining.Remove(bestCandidate!);
+        }
+
+        return result;
+    }
+}

--- a/XerifeTv.CMS/Modules/Content/ContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/ContentV2Service.cs
@@ -286,8 +286,8 @@ public class ContentV2Service(
             {
                 FeaturedContent = featuredContent,
                 FeaturedContentType = featuredType,
-                MovieCategores = (await GetMoviesCategoriesAsync(5)).Data ?? [],
-                SeriesCategores = (await GetSeriesCategoriesAsync(5)).Data ?? []
+                MovieCategores = (await GetMoviesCategoriesAsync(6)).Data ?? [],
+                SeriesCategores = (await GetSeriesCategoriesAsync(6)).Data ?? []
             });
         }
         catch (Exception ex)
@@ -304,6 +304,7 @@ public class ContentV2Service(
         try
         {
             var moviesByCategories = await _movieRepository.GetGroupByCategoryAsync(new(categories, page, pageSize));
+            moviesByCategories = CategoryDistributor.SpreadCategories(moviesByCategories);
 
             return Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>.Success(new(
                 currentPage: page,
@@ -326,6 +327,7 @@ public class ContentV2Service(
         try
         {
             var seriesByCategories = await _seriesRepository.GetGroupByCategoryAsync(new(categories, page, pageSize));
+            seriesByCategories = CategoryDistributor.SpreadCategories(seriesByCategories);
 
             return Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>.Success(new(
                 currentPage: page,


### PR DESCRIPTION
- Update endpoint category limits to 15 and 6.
- Add CategoryDistributor with SpreadCategories for better distribution and lower similarity between movie and series categories.
- Integrate the new logic into the corresponding services.