### PR TITLE
refactor(content): remove redundant categories in SpreadCategories and adjust page size

### DIFF
--- a/XerifeTv.CMS/Modules/BackgroundJobQueue/ProcessorStrategies/CalculateCategoryDistributionBackgroundJobProcessorStrategy.cs
+++ b/XerifeTv.CMS/Modules/BackgroundJobQueue/ProcessorStrategies/CalculateCategoryDistributionBackgroundJobProcessorStrategy.cs
@@ -127,14 +127,61 @@ public class CalculateCategoryDistributionBackgroundJobProcessorStrategy : IBack
 
     private static IEnumerable<string> SpreadCategories<T>(IEnumerable<ItemsByCategory<T>> categories) where T : BaseEntity
     {
+        const double RedundancyThreshold = 0.6;
+
         var categoryList = categories.ToList();
 
         if (categoryList.Count <= 2)
             return categoryList.Select(c => c.Category);
 
-        int count = categoryList.Count;
+        int rawCount = categoryList.Count;
 
-        var itemSets = categoryList
+        var rawItemSets = categoryList
+            .Select(x => x.Items.Select(i => i.Id).ToHashSet())
+            .ToArray();
+
+        // 1) Remove categorias redundantes (>= 70% de sobreposição com outra categoria maior/igual)
+        var excluded = new HashSet<int>();
+
+        for (int i = 0; i < rawCount; i++)
+        {
+            if (excluded.Contains(i))
+                continue;
+
+            for (int j = 0; j < rawCount; j++)
+            {
+                if (i == j || excluded.Contains(j))
+                    continue;
+
+                // só considera "absorver" i em j se j for maior ou igual (evita remover ambos os lados)
+                if (rawItemSets[j].Count < rawItemSets[i].Count)
+                    continue;
+
+                if (rawItemSets[i].Count == 0)
+                    continue;
+
+                int common = rawItemSets[i].Count(item => rawItemSets[j].Contains(item));
+                double overlapRatio = (double)common / rawItemSets[i].Count;
+
+                if (overlapRatio >= RedundancyThreshold)
+                {
+                    excluded.Add(i);
+                    break;
+                }
+            }
+        }
+
+        var filteredList = categoryList
+            .Where((_, idx) => !excluded.Contains(idx))
+            .ToList();
+
+        if (filteredList.Count <= 2)
+            return filteredList.Select(c => c.Category);
+
+        // 2) A partir daqui, segue exatamente a lógica original, mas sobre a lista filtrada
+        int count = filteredList.Count;
+
+        var itemSets = filteredList
             .Select(x => x.Items.Select(i => i.Id).ToHashSet())
             .ToArray();
 
@@ -202,6 +249,6 @@ public class CalculateCategoryDistributionBackgroundJobProcessorStrategy : IBack
             remaining.Remove(bestCandidate);
         }
 
-        return result.Select(i => categoryList[i].Category);
+        return result.Select(i => filteredList[i].Category);
     }
 }

--- a/XerifeTv.CMS/Modules/Content/ContentConstants.cs
+++ b/XerifeTv.CMS/Modules/Content/ContentConstants.cs
@@ -2,6 +2,6 @@
 
 public class ContentConstants
 {
-    public static readonly int DefaultPageSizeContent = 16;
+    public static readonly int DefaultPageSizeContent = 15;
     public static readonly int DefaultPageSizeMin = 10;
 }


### PR DESCRIPTION
Adds logic to filter out redundant categories in SpreadCategories<T> based on item overlap (>= 70% similarity with a larger or equal category is excluded). Updates return to use the filtered list. Changes DefaultPageSizeContent from 16 to 15 in ContentConstants.cs.