### PR TITLE
refactor: improve performance and redundant category filtering

### DIFF
--- a/XerifeTv.CMS/Modules/BackgroundJobQueue/ProcessorStrategies/CalculateCategoryDistributionBackgroundJobProcessorStrategy.cs
+++ b/XerifeTv.CMS/Modules/BackgroundJobQueue/ProcessorStrategies/CalculateCategoryDistributionBackgroundJobProcessorStrategy.cs
@@ -127,7 +127,7 @@ public class CalculateCategoryDistributionBackgroundJobProcessorStrategy : IBack
 
     private static IEnumerable<string> SpreadCategories<T>(IEnumerable<ItemsByCategory<T>> categories) where T : BaseEntity
     {
-        const double RedundancyThreshold = 0.6;
+        const double RedundancyThreshold = 0.7;
 
         var categoryList = categories.ToList();
 
@@ -140,7 +140,6 @@ public class CalculateCategoryDistributionBackgroundJobProcessorStrategy : IBack
             .Select(x => x.Items.Select(i => i.Id).ToHashSet())
             .ToArray();
 
-        // 1) Remove categorias redundantes (>= 70% de sobreposição com outra categoria maior/igual)
         var excluded = new HashSet<int>();
 
         for (int i = 0; i < rawCount; i++)
@@ -153,7 +152,6 @@ public class CalculateCategoryDistributionBackgroundJobProcessorStrategy : IBack
                 if (i == j || excluded.Contains(j))
                     continue;
 
-                // só considera "absorver" i em j se j for maior ou igual (evita remover ambos os lados)
                 if (rawItemSets[j].Count < rawItemSets[i].Count)
                     continue;
 
@@ -178,7 +176,6 @@ public class CalculateCategoryDistributionBackgroundJobProcessorStrategy : IBack
         if (filteredList.Count <= 2)
             return filteredList.Select(c => c.Category);
 
-        // 2) A partir daqui, segue exatamente a lógica original, mas sobre a lista filtrada
         int count = filteredList.Count;
 
         var itemSets = filteredList

--- a/XerifeTv.CMS/Modules/Movie/MovieRepository.cs
+++ b/XerifeTv.CMS/Modules/Movie/MovieRepository.cs
@@ -67,27 +67,36 @@ public sealed class MovieRepository(IOptions<DBSettings> options)
 
     public async Task<IEnumerable<ItemsByCategory<MovieEntity>>> GetGroupByCategoryAsync(GetGroupByCategoryRequestDto dto)
     {
-        List<ItemsByCategory<MovieEntity>> result = [];
-        List<string> uniqueMovieIds = [];
+        var fetchTasks = dto.Categories
+            .Select(category => _collection
+                .Find(r => r.Categories.Contains(category) && (!r.Disabled || dto.IsIncludeDisabled))
+                .SortByDescending(x => x.CreateAt)
+                .Skip(dto.LimitResults * (dto.CurrentPage - 1))
+                .Limit(dto.LimitResults)
+                .ToListAsync())
+            .ToList();
 
-        foreach (var category in dto.Categories)
+        var moviesPerCategory = await Task.WhenAll(fetchTasks);
+
+        var result = new List<ItemsByCategory<MovieEntity>>(dto.Categories.Count);
+        var seenMoviesIds = new HashSet<string>();
+        var categoriesArray = dto.Categories.ToArray();
+
+        for (var i = 0; i < categoriesArray.Length; i++)
         {
-            var moviesByCategory = await _collection
-              .Find(r => r.Categories.Any(x => x.Equals(category)) && (!r.Disabled || dto.IsIncludeDisabled))
-              .SortByDescending(x => x.CreateAt)
-              .Skip(dto.LimitResults * (dto.CurrentPage - 1))
-              .Limit(dto.LimitResults)
-              .ToListAsync();
+            var moviesByCategory = moviesPerCategory[i];
+            if (moviesByCategory.Count == 0)
+                continue;
 
             var orderedMovies = moviesByCategory
-                .OrderBy(x => uniqueMovieIds.Contains(x.Id))
+                .OrderBy(x => seenMoviesIds.Contains(x.Id))
                 .ThenByDescending(x => x.CreateAt)
                 .ToList();
 
-            uniqueMovieIds.AddRange(moviesByCategory.Select(x => x.Id));
+            foreach (var s in moviesByCategory)
+                seenMoviesIds.Add(s.Id);
 
-            if (moviesByCategory.Any())
-                result.Add(new ItemsByCategory<MovieEntity>(category, orderedMovies));
+            result.Add(new ItemsByCategory<MovieEntity>(categoriesArray[i], orderedMovies));
         }
 
         return result;

--- a/XerifeTv.CMS/Modules/Series/SeriesRepository.cs
+++ b/XerifeTv.CMS/Modules/Series/SeriesRepository.cs
@@ -92,27 +92,36 @@ public sealed class SeriesRepository(IOptions<DBSettings> options)
 
     public async Task<IEnumerable<ItemsByCategory<SeriesEntity>>> GetGroupByCategoryAsync(GetGroupByCategoryRequestDto dto)
     {
-        List<ItemsByCategory<SeriesEntity>> result = [];
-        List<string> uniqueSeriesIds = [];
+        var fetchTasks = dto.Categories
+            .Select(category => _collection
+                .Find(r => r.Categories.Contains(category) && (!r.Disabled || dto.IsIncludeDisabled))
+                .SortByDescending(x => x.CreateAt)
+                .Skip(dto.LimitResults * (dto.CurrentPage - 1))
+                .Limit(dto.LimitResults)
+                .ToListAsync())
+            .ToList();
 
-        foreach (var category in dto.Categories)
+        var seriesPerCategory = await Task.WhenAll(fetchTasks);
+
+        var result = new List<ItemsByCategory<SeriesEntity>>(dto.Categories.Count);
+        var seenSeriesIds = new HashSet<string>();
+        var categoriesArray = dto.Categories.ToArray();
+
+        for (var i = 0; i < categoriesArray.Length; i++)
         {
-            var seriesByCategory = await _collection
-              .Find(r => r.Categories.Any(x => x.Equals(category)) && (!r.Disabled || dto.IsIncludeDisabled))
-              .SortByDescending(x => x.CreateAt)
-              .Skip(dto.LimitResults * (dto.CurrentPage - 1))
-              .Limit(dto.LimitResults)
-              .ToListAsync();
+            var seriesByCategory = seriesPerCategory[i];
+            if (seriesByCategory.Count == 0)
+                continue;
 
             var orderedSeries = seriesByCategory
-                .OrderBy(x => uniqueSeriesIds.Contains(x.Id))
+                .OrderBy(x => seenSeriesIds.Contains(x.Id))
                 .ThenByDescending(x => x.CreateAt)
                 .ToList();
 
-            uniqueSeriesIds.AddRange(seriesByCategory.Select(x => x.Id));
+            foreach (var s in seriesByCategory)
+                seenSeriesIds.Add(s.Id);
 
-            if (seriesByCategory.Any())
-                result.Add(new ItemsByCategory<SeriesEntity>(category, orderedSeries));
+            result.Add(new ItemsByCategory<SeriesEntity>(categoriesArray[i], orderedSeries));
         }
 
         return result;


### PR DESCRIPTION
- Increase the redundancy threshold to 0.7 for stricter filtering
- Parallelize category repository queries using Task.WhenAll
- Use HashSet to optimize tracking of processed items
- Exclude empty categories from the returned results
- Refactor the implementation for improved clarity and performance