### PR TITLE
feat: adopt SSE for real-time job notifications

### DIFF
--- a/XerifeTv.CMS/Controllers/BackgroundJobQueueController.cs
+++ b/XerifeTv.CMS/Controllers/BackgroundJobQueueController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
 using XerifeTv.CMS.Modules.BackgroundJobQueue.Dtos.Request;
 using XerifeTv.CMS.Modules.BackgroundJobQueue.Enums;
 using XerifeTv.CMS.Modules.BackgroundJobQueue.Interfaces;
@@ -13,86 +14,101 @@ namespace XerifeTv.CMS.Controllers;
 [Authorize]
 public class BackgroundJobQueueController(IBackgroundJobQueueService _service, IUserService _userService) : Controller
 {
-	private const int limitResultsPage = 15;
+    private const int limitResultsPage = 15;
 
-	[Authorize(Roles = "admin, common")]
-	public async Task<IActionResult> Index(int? currentPage, string? username, EBackgroundJobStatus? status)
-	{
-		var modelView = new BackgroundJobQueueModelView();
-		var usernameSearch = User.Identity?.Name;
+    [Authorize(Roles = "admin, common")]
+    public async Task<IActionResult> Index(int? currentPage, string? username, EBackgroundJobStatus? status)
+    {
+        var modelView = new BackgroundJobQueueModelView();
+        var usernameSearch = User.Identity?.Name;
 
-		if (User.IsInRole("admin"))
-		{
-			usernameSearch = username ?? User.Identity?.Name;
-			var usersResult = await _userService.GetAsync(currentPage: 1, limit: 1000, includeAdmin: true);
-			if (usersResult.IsSuccess) modelView.Users = usersResult.Data?.Items.Where(u => u.Role != EUserRole.VISITOR) ?? [];
-		}
+        if (User.IsInRole("admin"))
+        {
+            usernameSearch = username ?? User.Identity?.Name;
+            var usersResult = await _userService.GetAsync(currentPage: 1, limit: 1000, includeAdmin: true);
+            if (usersResult.IsSuccess) modelView.Users = usersResult.Data?.Items.Where(u => u.Role != EUserRole.VISITOR) ?? [];
+        }
 
-		var jobsResult = await _service.GetByFilterAsync(new GetBackgroundJobsByFilterRequestDto(
-			order: EBackgroundJobOrderFilter.REGISTRATION_DATE_DESC,
-			limitResults: limitResultsPage,
-			currentPage: currentPage ?? 1,
-			responsibleUsername: usernameSearch,
-			status));
+        var jobsResult = await _service.GetByFilterAsync(new GetBackgroundJobsByFilterRequestDto(
+            order: EBackgroundJobOrderFilter.REGISTRATION_DATE_DESC,
+            limitResults: limitResultsPage,
+            currentPage: currentPage ?? 1,
+            responsibleUsername: usernameSearch,
+            status));
 
-		if (jobsResult.IsSuccess)
-		{
-			modelView.Jobs = jobsResult.Data?.Items ?? [];
-			ViewBag.CurrentPage = jobsResult.Data?.CurrentPage;
-			ViewBag.TotalPages = jobsResult.Data?.TotalPageCount ?? 1;
-			ViewBag.HasNextPage = jobsResult.Data?.HasNext;
-			ViewBag.HasPrevPage = jobsResult.Data?.HasPrevious;
-			ViewBag.Username = usernameSearch;
-			ViewBag.Status = status != null ? $"{(int)status}" : string.Empty;
+        if (jobsResult.IsSuccess)
+        {
+            modelView.Jobs = jobsResult.Data?.Items ?? [];
+            ViewBag.CurrentPage = jobsResult.Data?.CurrentPage;
+            ViewBag.TotalPages = jobsResult.Data?.TotalPageCount ?? 1;
+            ViewBag.HasNextPage = jobsResult.Data?.HasNext;
+            ViewBag.HasPrevPage = jobsResult.Data?.HasPrevious;
+            ViewBag.Username = usernameSearch;
+            ViewBag.Status = status != null ? $"{(int)status}" : string.Empty;
 
-			return View(modelView);
-		}
+            return View(modelView);
+        }
 
-		TempData["Notification"] = MessageViewHelper.ErrorJson(jobsResult.Error.Description ?? string.Empty);
+        TempData["Notification"] = MessageViewHelper.ErrorJson(jobsResult.Error.Description ?? string.Empty);
 
-		return View(modelView);
-	}
+        return View(modelView);
+    }
 
-	[HttpPost]
-	[Authorize(Roles = "admin, common")]
-	public async Task<IActionResult> AddJobInQueueSpreadsheetRegisters(AddSpreadsheetJobQueueRequestDto dto)
-	{
-		dto.RequestedByUsername = User?.Identity?.Name ?? string.Empty;
-		var response = await _service.AddJobInQueueAsync(dto);
+    [HttpPost]
+    [Authorize(Roles = "admin, common")]
+    public async Task<IActionResult> AddJobInQueueSpreadsheetRegisters(AddSpreadsheetJobQueueRequestDto dto)
+    {
+        dto.RequestedByUsername = User?.Identity?.Name ?? string.Empty;
+        var response = await _service.AddJobInQueueAsync(dto);
 
-		if (response.IsFailure) return BadRequest(response.Error.Description);
+        if (response.IsFailure) return BadRequest(response.Error.Description);
 
-		TempData["Notification"] = response.IsFailure
-		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson($"Processo adicionado a fila com sucesso");
+        TempData["Notification"] = response.IsFailure
+          ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
+          : MessageViewHelper.SuccessJson($"Processo adicionado a fila com sucesso");
 
-		return Ok(response.Data);
-	}
+        return Ok(response.Data);
+    }
 
-	[HttpPost]
-	[Authorize(Roles = "admin, common")]
-	public async Task<IActionResult> AddJobInQueueImportEpisodesSeries(AddImportEpisodesJobQueueRequestDto dto)
-	{
-		dto.RequestedByUsername = User?.Identity?.Name ?? string.Empty;
-		var response = await _service.AddJobInQueueAsync(dto);
+    [HttpPost]
+    [Authorize(Roles = "admin, common")]
+    public async Task<IActionResult> AddJobInQueueImportEpisodesSeries(AddImportEpisodesJobQueueRequestDto dto)
+    {
+        dto.RequestedByUsername = User?.Identity?.Name ?? string.Empty;
+        var response = await _service.AddJobInQueueAsync(dto);
 
-		if (response.IsFailure) return BadRequest(response.Error.Description);
+        if (response.IsFailure) return BadRequest(response.Error.Description);
 
-		TempData["Notification"] = response.IsFailure
-		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson($"Processo adicionado a fila com sucesso");
+        TempData["Notification"] = response.IsFailure
+          ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
+          : MessageViewHelper.SuccessJson($"Processo adicionado a fila com sucesso");
 
-		return Ok(response.Data);
-	}
+        return Ok(response.Data);
+    }
 
-	[HttpGet]
-	[Authorize(Roles = "admin, common")]
-	public async Task<IActionResult> GetJobsNotification()
-	{
-		var response = await _service.GetJobsToNotifyAsync(username: User?.Identity?.Name ?? string.Empty);
+    [HttpGet]
+    [Authorize(Roles = "admin, common")]
+    public async Task GetJobsNotification(CancellationToken cancellationToken)
+    {
+        Response.Headers.Append("Content-Type", "text/event-stream");
+        Response.Headers.Append("Cache-Control", "no-cache");
+        Response.Headers.Append("Connection", "keep-alive");
 
-		if (response.IsFailure) return BadRequest(response.Error.Description);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, HttpContext.RequestAborted);
 
-		return Ok(response.Data);
-	}
+        try
+        {
+            while (!linked.IsCancellationRequested)
+            {
+                var response = await _service.GetJobsToNotifyAsync(username: User?.Identity?.Name ?? string.Empty);
+
+                var payload = $"data: {JsonSerializer.Serialize(response.Data)}\n\n";
+                await Response.WriteAsync(payload, linked.Token);
+                await Response.Body.FlushAsync(linked.Token);
+
+                await Task.Delay(TimeSpan.FromSeconds(5), linked.Token);
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
 }

--- a/XerifeTv.CMS/Views/Shared/_Layout.cshtml
+++ b/XerifeTv.CMS/Views/Shared/_Layout.cshtml
@@ -87,7 +87,7 @@
 </head>
 <body>
     <script>
-            (function() {
+            (function () {
                 const theme = localStorage.getItem('theme') || 'light';
                 document.documentElement.setAttribute('data-bs-theme', theme);
                 if (theme === 'dark') document.body.classList.add('bg-dark');
@@ -249,36 +249,41 @@
     @if (!User.IsInRole("visitor") && !pagesViewWithoutTemplate.Contains(ViewData["title"]?.ToString()))
     {
         <script>
+                const jobsEventSource = new EventSource('/BackgroundJobQueue/GetJobsNotification');
 
-                setInterval(async () => {
-                    var response = await fetch('/BackgroundJobQueue/GetJobsNotification');
-                    var data = await response.json();
+                jobsEventSource.onmessage = (e) => {
+                    const data = JSON.parse(e.data);
 
                     for (const jobNotification of data) {
+                        if (document.getElementById(`jobNotification${jobNotification.JobId}`)) continue;
+
                         var statusText = 'Concluido';
-                        if (jobNotification.jobStatus == '@((int)EBackgroundJobStatus.FAILED)') statusText = 'Falha no processamento';
-                        if (jobNotification.jobStatus == '@((int)EBackgroundJobStatus.CANCELED)') statusText = 'Cancelado';
+                        if (jobNotification.JobStatus == '@((int)EBackgroundJobStatus.FAILED)') statusText = 'Falha no processamento';
+                        if (jobNotification.JobStatus == '@((int)EBackgroundJobStatus.CANCELED)') statusText = 'Cancelado';
 
                         $('.toast-container').append(`
-                              <div id="jobNotification${jobNotification.jobId}" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-                                  <div class="toast-header">
-                                      <i class="fa-solid fa-bell"></i>
-                                      <strong class="me-auto ms-2">${statusText}</strong>
-                                      <small>${jobNotification.jobTimeAgo}</small>
-                                      <button type="button" class="btn-close shadow-none" data-bs-dismiss="toast" aria-label="Close"></button>
-                                  </div>
-                                  <div class="toast-body text-truncate" style="max-width: 100%;">
-                                    ${jobNotification.jobName}
-                                  </div>
-                              </div>
-                            `);
+                                                  <div id="jobNotification${jobNotification.JobId}" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+                                                      <div class="toast-header">
+                                                          <i class="fa-solid fa-bell"></i>
+                                                          <strong class="me-auto ms-2">${statusText}</strong>
+                                                          <small>${jobNotification.JobTimeAgo}</small>
+                                                          <button type="button" class="btn-close shadow-none" data-bs-dismiss="toast" aria-label="Close"></button>
+                                                      </div>
+                                                      <div class="toast-body text-truncate" style="max-width: 100%;">
+                                                        ${jobNotification.JobName}
+                                                      </div>
+                                                  </div>
+                                                `);
 
-                        const toastNotification = document.getElementById(`jobNotification${jobNotification.jobId}`);
+                        const toastNotification = document.getElementById(`jobNotification${jobNotification.JobId}`);
                         const toastBootstrap = new bootstrap.Toast(toastNotification, { autohide: false });
                         toastBootstrap.show();
                     }
-                }, 8000);
+                };
 
+                jobsEventSource.onerror = (err) => {
+                    console.error('Erro na conexão SSE de notificações', err);
+                };
         </script>
     }
 </body>


### PR DESCRIPTION
Convert the GetJobsNotification endpoint from polling to Server-Sent Events (SSE), enabling continuous, real-time delivery of job notifications instead of the previous 8-second fetch interval.

Backend:
- Set Content-Type: text/event-stream, Cache-Control: no-cache, and Connection: keep-alive on the response.
- Link the incoming CancellationToken with HttpContext.RequestAborted so the loop stops as soon as the client disconnects.
- Stream JSON payloads via Response.WriteAsync/FlushAsync every 5 seconds instead of returning a single JSON response.
- Wrap the loop in a try/catch for OperationCanceledException to avoid unhandled-exception noise on normal client disconnects.

Frontend:
- Replace the setInterval + fetch polling loop with a persistent EventSource connection to GetJobsNotification.
- Update notification handling to read the payload fields in PascalCase, matching the backend's JSON serialization.
- Add an onerror handler to log SSE connection errors (EventSource retains its built-in auto-reconnect behavior).
- Minor formatting cleanup in the theme script.