### PR TITLE
chore: review and standardize application text

### DIFF
--- a/XerifeTv.CMS/Controllers/MediaDeliveryProfilesController.cs
+++ b/XerifeTv.CMS/Controllers/MediaDeliveryProfilesController.cs
@@ -22,7 +22,7 @@ public class MediaDeliveryProfilesController(
 
         TempData["Notification"] = response.IsFailure
           ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-          : MessageViewHelper.SuccessJson($"Perfil Entrega de Midia cadastrado com sucesso");
+          : MessageViewHelper.SuccessJson($"Perfil Entrega de Mídia cadastrado com sucesso");
 
         _logger.LogInformation($"{User.Identity?.Name} registered the media delivery profile {dto.Name}");
 
@@ -35,7 +35,7 @@ public class MediaDeliveryProfilesController(
 
         TempData["Notification"] = response.IsFailure
           ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-          : MessageViewHelper.SuccessJson($"Perfil Entrega de Midia atualizado com sucesso");
+          : MessageViewHelper.SuccessJson($"Perfil Entrega de Mídia atualizado com sucesso");
 
         _logger.LogInformation($"{User.Identity?.Name} updated the media delivery profile {dto.Name}");
 
@@ -50,7 +50,7 @@ public class MediaDeliveryProfilesController(
 
             TempData["Notification"] = response.IsFailure
               ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-              : MessageViewHelper.SuccessJson($"Perfil Entrega de Midia deletado com sucesso");
+              : MessageViewHelper.SuccessJson($"Perfil Entrega de Mídia deletado com sucesso");
 
             _logger.LogInformation($"{User.Identity?.Name} removed the media delivery profile with id = {id}");
         }

--- a/XerifeTv.CMS/Controllers/SeriesController.cs
+++ b/XerifeTv.CMS/Controllers/SeriesController.cs
@@ -100,7 +100,7 @@ public class SeriesController(
 
 		TempData["Notification"] = response.IsFailure
 		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson($"Serie {dto.ImdbId} cadastrada com sucesso");
+		  : MessageViewHelper.SuccessJson($"Série {dto.ImdbId} cadastrada com sucesso");
 
 		_logger.LogInformation($"{User.Identity?.Name} registered the serie {dto.Title}");
 
@@ -114,7 +114,7 @@ public class SeriesController(
 
 		TempData["Notification"] = response.IsFailure
 		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson($"Serie {dto.ImdbId} atualizada com sucesso");
+		  : MessageViewHelper.SuccessJson($"Série {dto.ImdbId} atualizada com sucesso");
 
 		_logger.LogInformation($"{User.Identity?.Name} updated the serie {dto.Title}");
 
@@ -130,7 +130,7 @@ public class SeriesController(
 
 			TempData["Notification"] = response.IsFailure
 			  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-			  : MessageViewHelper.SuccessJson($"Serie deletada com sucesso");
+			  : MessageViewHelper.SuccessJson($"Série deletada com sucesso");
 
 			_logger.LogInformation($"{User.Identity?.Name} removed the serie with id = {id}");
 		}
@@ -169,7 +169,7 @@ public class SeriesController(
 
 		TempData["Notification"] = response.IsFailure
 		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson($"Episodio T{dto.Season}:EP{dto.Number} cadastrado com sucesso");
+		  : MessageViewHelper.SuccessJson($"Episódio T{dto.Season}:EP{dto.Number} cadastrado com sucesso");
 
 		_logger.LogInformation($"{User.Identity?.Name} registered episode {dto.Number} of season {dto.Season} of the serie with id = {dto.SerieId}");
 
@@ -183,7 +183,7 @@ public class SeriesController(
 
 		TempData["Notification"] = response.IsFailure
 		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson($"Episodio T{dto.Season}:EP{dto.Number} atualizado com sucesso");
+		  : MessageViewHelper.SuccessJson($"Episódio T{dto.Season}:EP{dto.Number} atualizado com sucesso");
 
 		_logger.LogInformation($"{User.Identity?.Name} updated episode {dto.Number} of season {dto.Season} of the serie with id = {dto.SerieId}");
 
@@ -199,7 +199,7 @@ public class SeriesController(
 
 			TempData["Notification"] = response.IsFailure
 			  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-			  : MessageViewHelper.SuccessJson($"Episodio deletado com sucesso");
+			  : MessageViewHelper.SuccessJson($"Episódio deletado com sucesso");
 
 			_logger.LogInformation($"{User.Identity?.Name} deleted episode with id = {id} of the serie with id = {serieId}");
 		}
@@ -241,7 +241,7 @@ public class SeriesController(
 
 		if (response.IsSuccess && response.Data?.ProgressCount == 100 && response.Data.SuccessCount > 1)
 			TempData["Notification"] = MessageViewHelper
-			  .SuccessJson($"{response.Data.SuccessCount} series/episodios cadastrados/atualizados com sucesso");
+			  .SuccessJson($"{response.Data.SuccessCount} séries/episódios cadastrados/atualizados com sucesso");
 
 		if (response.IsSuccess)
 			return Ok(response.Data);
@@ -255,7 +255,7 @@ public class SeriesController(
 	{
 		if (string.IsNullOrEmpty(dto.SeriesId))
 		{
-			TempData["Notification"] = MessageViewHelper.ErrorJson("Ops! Houve um problema [serie invalida]");
+			TempData["Notification"] = MessageViewHelper.ErrorJson("Ops! Houve um problema [série inválida]");
 			return BadRequest();
 		}
 
@@ -275,7 +275,7 @@ public class SeriesController(
 
 		if (response.IsSuccess && response.Data?.ProgressCount == 100 && response.Data.ImportedCount > 1)
 			TempData["Notification"] = MessageViewHelper
-			  .SuccessJson($"{response.Data.ImportedCount} episodios importados com sucesso");
+			  .SuccessJson($"{response.Data.ImportedCount} episódios importados com sucesso");
 
 		if (response.IsSuccess)
 			return Ok(response.Data);

--- a/XerifeTv.CMS/Controllers/UsersController.cs
+++ b/XerifeTv.CMS/Controllers/UsersController.cs
@@ -161,7 +161,7 @@ public class UsersController(
 
 		TempData["Notification"] = response.IsFailure
 		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson($"Usuario {dto.UserName} cadastrado com sucesso");
+		  : MessageViewHelper.SuccessJson($"Usuário {dto.UserName} cadastrado com sucesso");
 
 		_logger.LogInformation($"{User.Identity?.Name} registered a new user");
 
@@ -176,7 +176,7 @@ public class UsersController(
 
 		TempData["Notification"] = response.IsFailure
 		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson($"Usuario {dto.UserName} atualizado com sucesso");
+		  : MessageViewHelper.SuccessJson($"Usuário {dto.UserName} atualizado com sucesso");
 
 		_logger.LogInformation($"{User.Identity?.Name} updated user {dto.Id}");
 		return RedirectToAction("Index");
@@ -189,7 +189,7 @@ public class UsersController(
 
 		TempData["Notification"] = response.IsFailure
 		  ? MessageViewHelper.ErrorJson(response.Error.Description ?? string.Empty)
-		  : MessageViewHelper.SuccessJson("Usuario deletado com sucesso");
+		  : MessageViewHelper.SuccessJson("Usuário deletado com sucesso");
 
 		_logger.LogInformation($"{User.Identity?.Name} removed user with id = {id}");
 

--- a/XerifeTv.CMS/Modules/Abstractions/Services/SpreadsheetReaderService.cs
+++ b/XerifeTv.CMS/Modules/Abstractions/Services/SpreadsheetReaderService.cs
@@ -13,7 +13,7 @@ public class SpreadsheetReaderService : ISpreadsheetReaderService
         {
             using var package = new ExcelPackage(fileStream);
             var worksheet = package.Workbook.Worksheets[worksheetIndex] 
-                ?? throw new SpreadsheetInvalidException("Planilha vazia ou nao encontrada");
+                ?? throw new SpreadsheetInvalidException("Planilha vazia ou não encontrada");
 
             var spreadsheetColumns = new List<string>();
             for (int col = 1; col <= worksheet.Dimension.End.Column; col++)

--- a/XerifeTv.CMS/Modules/Authentication/Services/AuthService.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Services/AuthService.cs
@@ -36,7 +36,7 @@ public class AuthService(
             var (isValid, userName) = await _tokenService.ValidateTokenAsync(refreshToken);
 
             if (!isValid)
-                return Result<(string?, string?)>.Failure(new Error("401", "Token invalido"));
+                return Result<(string?, string?)>.Failure(new Error("401", "Token inválido"));
 
             var response = await _userService.GetByUsernameAsync(userName!);
 
@@ -46,7 +46,7 @@ public class AuthService(
             var userResult = response.Data!;
 
             if (userResult.Blocked)
-                return Result<(string?, string?)>.Failure(new Error("403", "Usuario bloqueado"));
+                return Result<(string?, string?)>.Failure(new Error("403", "Usuário bloqueado"));
 
             return Result<(string?, string?)>.Success((
                 _tokenService.GenerateToken(userResult.UserName, userResult.Role),

--- a/XerifeTv.CMS/Modules/Authentication/Services/BasicLoginStrategy.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Services/BasicLoginStrategy.cs
@@ -24,7 +24,7 @@ public class BasicLoginStrategy(IUserService _userService, ITokenService _tokenS
 			var userResult = response.Data!;
 
 			if (userResult.Blocked)
-				return Result<LoginResponseDto>.Failure(new Error("403", "Usuario bloqueado"));
+				return Result<LoginResponseDto>.Failure(new Error("403", "Usuário bloqueado"));
 
 			var isPasswordCorrectResponse = await _userService.IsPasswordCorrect(userResult.Id, dto.Password);
 
@@ -32,7 +32,7 @@ public class BasicLoginStrategy(IUserService _userService, ITokenService _tokenS
 				return Result<LoginResponseDto>.Failure(isPasswordCorrectResponse.Error);
 
 			if (!isPasswordCorrectResponse.Data)
-				return Result<LoginResponseDto>.Failure(new Error("401", "Credenciais invalidas"));
+				return Result<LoginResponseDto>.Failure(new Error("401", "Credênciais inválidas"));
 
 			return Result<LoginResponseDto>.Success(
 				new LoginResponseDto(

--- a/XerifeTv.CMS/Modules/Authentication/Services/GoogleLoginStrategy.cs
+++ b/XerifeTv.CMS/Modules/Authentication/Services/GoogleLoginStrategy.cs
@@ -30,12 +30,12 @@ public class GoogleLoginStrategy(
 				return Result<LoginResponseDto>.Failure(new Error("401", "Erro ao validar o token Google"));
 
 			if (payload.Aud != _configuration["OAuth2Google:ClientId"])
-				return Result<LoginResponseDto>.Failure(new Error("401", "Token Google invalido: client ID nao autorizado"));
+				return Result<LoginResponseDto>.Failure(new Error("401", "Token Google inválido: client ID não autorizado"));
 
 			var expiry = DateTimeOffset.FromUnixTimeSeconds(long.Parse(payload!.Exp));
 
 			if (expiry < DateTimeOffset.UtcNow)
-				return Result<LoginResponseDto>.Failure(new Error("401", "Token Google invalido ou expirado"));
+				return Result<LoginResponseDto>.Failure(new Error("401", "Token Google inválido ou expirado"));
 
 			var userResponse = await _userService.GetByEmailAsync(payload!.Email);
 
@@ -45,7 +45,7 @@ public class GoogleLoginStrategy(
 			var userResult = userResponse.Data!;
 
 			if (userResult.Blocked)
-				return Result<LoginResponseDto>.Failure(new Error("403", "Usuario bloqueado"));
+				return Result<LoginResponseDto>.Failure(new Error("403", "Usuário bloqueado"));
 
 			return Result<LoginResponseDto>.Success(
 				new LoginResponseDto(

--- a/XerifeTv.CMS/Modules/BackgroundJobQueue/BackgroundJobEntity.cs
+++ b/XerifeTv.CMS/Modules/BackgroundJobQueue/BackgroundJobEntity.cs
@@ -35,8 +35,8 @@ public class BackgroundJobEntity : BaseEntity
             Type = type,
             JobName = type switch
             {
-                EBackgroundJobType.REGISTER_SPREADSHEET_MOVIES => $"Cadastro/Atualizacao de Filmes ({spreadsheetFileName})",
-                EBackgroundJobType.REGISTER_SPREADSHEET_SERIES => $"Cadastro/Atualizacao de Series ({spreadsheetFileName})",
+                EBackgroundJobType.REGISTER_SPREADSHEET_MOVIES => $"Cadastro/Atualização de Filmes ({spreadsheetFileName})",
+                EBackgroundJobType.REGISTER_SPREADSHEET_SERIES => $"Cadastro/Atualização de Séries ({spreadsheetFileName})",
                 EBackgroundJobType.REGISTER_SPREADSHEET_CHANNELS => $"Cadastro de Canais ({spreadsheetFileName})",
                 _ => string.Empty
             },
@@ -51,7 +51,7 @@ public class BackgroundJobEntity : BaseEntity
         return new BackgroundJobEntity
         {
             Type = EBackgroundJobType.IMPORT_EPISODES_FROM_SERIES_IMDB,
-            JobName = $"Importacao de Episodios via IMDB [{seriesImdbId}]",
+            JobName = $"Importação de Episódios via IMDB [{seriesImdbId}]",
             Status = EBackgroundJobStatus.PENDING,
             RequestedByUserId = userId,
             SeriesIdImportEpisodes = seriesId
@@ -67,8 +67,8 @@ public class BackgroundJobEntity : BaseEntity
                  : EBackgroundJobType.CALCULATE_CATEGORY_DISTRIBUTION_FOR_CONTENT_API_SERIES,
 
             JobName = type == ECalculateCategoryDistributionJobQueueType.MOVIES
-                ? "Calculo de Distribuicao de Categorias - Filmes"
-                : "Calculo de Distribuicao de Categorias - Series",
+                ? "Cálculo de Distribuição de Categorias - Filmes"
+                : "Cálculo de Distribuição de Categorias - Séries",
 
             Status = EBackgroundJobStatus.PENDING
         };
@@ -89,7 +89,7 @@ public class BackgroundJobEntity : BaseEntity
             JobName = type switch
             {
                 EDispatchWebhooksJobQueueType.MOVIES => "Disparo de Webhooks - Filmes",
-                EDispatchWebhooksJobQueueType.SERIES => "Disparo de Webhooks - Series",
+                EDispatchWebhooksJobQueueType.SERIES => "Disparo de Webhooks - Séries",
                 EDispatchWebhooksJobQueueType.CHANNELS => "Disparo de Webhooks - Canais",
                 _ => string.Empty
             },
@@ -102,10 +102,10 @@ public class BackgroundJobEntity : BaseEntity
     public BackgroundJobEntity Update(UpdateBackgroundJobRequestDto dto)
     {
         if (Status == EBackgroundJobStatus.COMPLETED || Status == EBackgroundJobStatus.FAILED)
-            throw new Exception("Background Job ja concluido");
+            throw new Exception("Background Job já concluído");
 
         if (TotalProcessedRecords > dto.TotalProcessedRecords)
-            throw new Exception("Nao foi possível reduzir o progresso. O valor atual ja esta maior ao informado");
+            throw new Exception("Não foi possível reduzir o progresso. O valor atual já está maior ao informado");
 
         if (dto.Status == EBackgroundJobStatus.PROCESSING && Status != EBackgroundJobStatus.PROCESSING)
             ProcessedAt = DateTime.UtcNow;

--- a/XerifeTv.CMS/Modules/BackgroundJobQueue/Services/BackgroundJobQueueService.cs
+++ b/XerifeTv.CMS/Modules/BackgroundJobQueue/Services/BackgroundJobQueueService.cs
@@ -24,7 +24,7 @@ public class BackgroundJobQueueService(
             var fileExtension = Path.GetExtension(dto.SpreadsheetFile?.FileName);
 
             if (dto.SpreadsheetFile == null || !_acceptedExtensions.Contains(fileExtension))
-                return Result<AddJobQueueResponseDto>.Failure(new Error("400", "Arquivo de planilha invalido"));
+                return Result<AddJobQueueResponseDto>.Failure(new Error("400", "Arquivo de planilha inválido"));
 
             var jobGuidId = Guid.NewGuid();
 
@@ -153,7 +153,7 @@ public class BackgroundJobQueueService(
             var response = await _repository.GetAsync(dto.Id);
 
             if (response == null)
-                return Result<string>.Failure(new Error("404", "Background Job nao encontrado"));
+                return Result<string>.Failure(new Error("404", "Background Job não encontrado"));
 
             await _repository.UpdateAsync(response.Update(dto));
 
@@ -173,7 +173,7 @@ public class BackgroundJobQueueService(
             var entity = await _repository.GetAsync(id);
 
             if (entity == null)
-                return Result<bool>.Failure(new Error("404", "Background Job nao encontrado"));
+                return Result<bool>.Failure(new Error("404", "Background Job não encontrado"));
 
             await _repository.DeleteAsync(id);
 

--- a/XerifeTv.CMS/Modules/Channel/ChannelService.cs
+++ b/XerifeTv.CMS/Modules/Channel/ChannelService.cs
@@ -40,7 +40,7 @@ public sealed class ChannelService(
 
             if (response is null)
                 return Result<GetChannelResponseDto?>
-                  .Failure(new Error("404", "Conteudo nao encontrado"));
+                  .Failure(new Error("404", "Conteúdo não encontrado"));
 
             return Result<GetChannelResponseDto?>
               .Success(GetChannelResponseDto.FromEntity(response));
@@ -61,7 +61,7 @@ public sealed class ChannelService(
 
             if (!await titleSpec.IsSatisfiedByAsync(entity))
             {
-                var errorMessage = $"Canal nao cadastrado. Titulo [{entity.Title}] duplicado";
+                var errorMessage = $"Canal não cadastrado. Título [{entity.Title}] duplicado";
                 return Result<string>.Failure(new Error("409", errorMessage));
             }
 
@@ -85,13 +85,13 @@ public sealed class ChannelService(
             var response = await _repository.GetAsync(entity.Id);
 
             if (response is null)
-                return Result<string>.Failure(new Error("404", "Conteudo nao encontrado"));
+                return Result<string>.Failure(new Error("404", "Conteúdo não encontrado"));
 
             var titleSpec = new UniqueTitleSpecification(_repository);
 
             if (!await titleSpec.IsSatisfiedByAsync(entity))
             {
-                var errorMessage = $"Canal nao cadastrado. Titulo [{entity.Title}] duplicado";
+                var errorMessage = $"Canal não cadastrado. Título [{entity.Title}] duplicado";
                 return Result<string>.Failure(new Error("409", errorMessage));
             }
 
@@ -113,7 +113,7 @@ public sealed class ChannelService(
             var response = await _repository.GetAsync(id);
 
             if (response is null)
-                return Result<bool>.Failure(new Error("404", "Conteudo nao encontrado"));
+                return Result<bool>.Failure(new Error("404", "Conteúdo não encontrado"));
 
             await _repository.DeleteAsync(id);
             return Result<bool>.Success(true);

--- a/XerifeTv.CMS/Modules/Channel/Dtos/Response/SpreadsheetChannelResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Channel/Dtos/Response/SpreadsheetChannelResponseDto.cs
@@ -31,12 +31,12 @@ public class SpreadsheetChannelResponseDto
 		];
 
 		if (requiredValues.Any(string.IsNullOrEmpty))
-			throw new SpreadsheetInvalidException($"[{title[..8]}] algum campo obrigatorio esta vazio");
+			throw new SpreadsheetInvalidException($"[{title[..8]}] algum campo obrigatório está vazio");
 		
 		if (!string.IsNullOrWhiteSpace(videoStreamFormat)
             && !StreamFormatsHelper.Streaming.Contains(videoStreamFormat) 
 		    && !StreamFormatsHelper.Vod.Contains(videoStreamFormat))
-			throw new SpreadsheetInvalidException($"[{title[..8]}] stream format invalido");
+			throw new SpreadsheetInvalidException($"[{title[..8]}] stream format inválido");
 
         var hasMediaDeliveryProfile =
             !string.IsNullOrWhiteSpace(mediaDeliveryProfileName) &&
@@ -47,7 +47,7 @@ public class SpreadsheetChannelResponseDto
             !string.IsNullOrWhiteSpace(videoStreamFormat);
 
         if (!hasMediaDeliveryProfile && !hasFixedVideo)
-            throw new SpreadsheetInvalidException($"[{title[..8]}] obrigatorio informar Media Delivery Profile/Media Path ou URL Video Fixed/Stream Format");
+            throw new SpreadsheetInvalidException($"[{title[..8]}] obrigatório informar Media Delivery Profile/Media Path ou URL Video Fixed/Stream Format");
 
 
         return new SpreadsheetChannelResponseDto

--- a/XerifeTv.CMS/Modules/Channel/Importers/ChannelsSpreadsheetImporter.cs
+++ b/XerifeTv.CMS/Modules/Channel/Importers/ChannelsSpreadsheetImporter.cs
@@ -33,7 +33,7 @@ public class ChannelsSpreadsheetImporter(
 
 		if (response == null)
 			return Result<ImportSpreadsheetResponseDto>.Failure(
-				new Error("400", $"Import Id {importId} nao encontrado"));
+				new Error("400", $"Import Id {importId} não encontrado"));
 
 		await Task.Delay(500);
 		return Result<ImportSpreadsheetResponseDto>.Success(response);

--- a/XerifeTv.CMS/Modules/Content/Services/ContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/Services/ContentV2Service.cs
@@ -53,7 +53,7 @@ public class ContentV2Service(
             var movie = await _movieRepository.GetAsync(id);
 
             if (movie is null || movie.Disabled)
-                return Result<MovieContentV2ResponseDto?>.Failure(new("404", "Conteudo nao encontrado"));
+                return Result<MovieContentV2ResponseDto?>.Failure(new("404", "Conteúdo não encontrado"));
 
             return Result<MovieContentV2ResponseDto?>.Success(
                 MovieContentV2ResponseDto.FromEntity(movie, _configuration["SecuritySettings:ContentEncryptionKey"]!));
@@ -71,7 +71,7 @@ public class ContentV2Service(
             var series = await _seriesRepository.GetAsync(id);
 
             if (series is null || series.Disabled)
-                return Result<SeriesSummaryContentV2ResponseDto?>.Failure(new("404", "Conteudo nao encontrado"));
+                return Result<SeriesSummaryContentV2ResponseDto?>.Failure(new("404", "Conteúdo não encontrado"));
 
             return Result<SeriesSummaryContentV2ResponseDto?>.Success(SeriesSummaryContentV2ResponseDto.FromEntity(series));
         }

--- a/XerifeTv.CMS/Modules/Franchise/FranchiseService.cs
+++ b/XerifeTv.CMS/Modules/Franchise/FranchiseService.cs
@@ -52,7 +52,7 @@ public class FranchiseService(
 
             if (response == null)
                 return Result<GetFranchiseResponseDto?>.Failure(
-                    new Error("404", "Franquia nao encontrada"));
+                    new Error("404", "Franquia não encontrada"));
 
             return Result<GetFranchiseResponseDto?>.Success(GetFranchiseResponseDto.FromEntity(response));
         }
@@ -71,7 +71,7 @@ public class FranchiseService(
 
             if (response == null)
                 return Result<GetFranchiseResponseDto?>.Failure(
-                    new Error("404", "Franquia nao encontrada"));
+                    new Error("404", "Franquia não encontrada"));
 
             return Result<GetFranchiseResponseDto?>.Success(
                 GetFranchiseResponseDto.FromEntity(response));
@@ -89,12 +89,12 @@ public class FranchiseService(
         {
             if (string.IsNullOrWhiteSpace(dto.Name))
                 return Result<GetFranchiseResponseDto>.Failure(
-                    new Error("400", "Nome da franquia obrigatorio"));
+                    new Error("400", "Nome da franquia obrigatório"));
 
             var existingFranchise = await _repository.GetByNameAsync(dto.Name);
             if (existingFranchise != null)
                 return Result<GetFranchiseResponseDto>.Failure(
-                    new Error("409", "Ja existe uma franquia com este nome"));
+                    new Error("409", "Já existe uma franquia com este nome"));
 
             var entity = dto.ToEntity();
             await _repository.CreateAsync(entity);
@@ -115,21 +115,21 @@ public class FranchiseService(
         {
             if (string.IsNullOrWhiteSpace(dto.Id))
                 return Result<GetFranchiseResponseDto>.Failure(
-                    new Error("400", "Franquia invalida"));
+                    new Error("400", "Franquia inválida"));
 
             if (string.IsNullOrWhiteSpace(dto.Name))
                 return Result<GetFranchiseResponseDto>.Failure(
-                    new Error("400", "Nome da franquia obrigatorio"));
+                    new Error("400", "Nome da franquia obrigatório"));
 
             var existingFranchise = await _repository.GetAsync(dto.Id);
             if (existingFranchise == null)
                 return Result<GetFranchiseResponseDto>.Failure(
-                    new Error("404", "Franquia nao encontrada"));
+                    new Error("404", "Franquia não encontrada"));
 
             var duplicatedFranchise = await _repository.GetByNameAsync(dto.Name, dto.Id);
             if (duplicatedFranchise != null)
                 return Result<GetFranchiseResponseDto>.Failure(
-                    new Error("409", "Ja existe uma franquia com este nome"));
+                    new Error("409", "Já existe uma franquia com este nome"));
 
             existingFranchise.Name = dto.Name.Trim();
             await _repository.UpdateAsync(existingFranchise);
@@ -150,14 +150,14 @@ public class FranchiseService(
         {
             var existingFranchise = await _repository.GetAsync(id);
             if (existingFranchise == null)
-                return Result<bool>.Failure(new Error("404", "Franquia nao encontrada"));
+                return Result<bool>.Failure(new Error("404", "Franquia não encontrada"));
 
             var moviesCount = await _movieRepository.CountByFranchiseIdAsync(id);
             var seriesCount = await _seriesRepository.CountByFranchiseIdAsync(id);
 
             if (moviesCount > 0 || seriesCount > 0)
                 return Result<bool>.Failure(
-                    new Error("409", "Nao foi possivel excluir! A franquia esta vinculada a outros filmes ou series"));
+                    new Error("409", "Não foi possível excluir! A franquia está vinculada a outros filmes ou séries"));
 
             await _repository.DeleteAsync(id);
             return Result<bool>.Success(true);

--- a/XerifeTv.CMS/Modules/Integrations/Imdb/Services/ImdbService.cs
+++ b/XerifeTv.CMS/Modules/Integrations/Imdb/Services/ImdbService.cs
@@ -25,7 +25,7 @@ public class ImdbService(IConfiguration _configuration) : IImdbService
 
             if (result is null)
                 return Result<GetAllResultsByImdbIdResponseDto?>.Failure(
-                    new Error("404", $"Imdb ID: {imdbId} invalido"));
+                    new Error("404", $"Imdb ID: {imdbId} inválido"));
 
             return Result<GetAllResultsByImdbIdResponseDto?>.Success(result);
         }
@@ -55,7 +55,7 @@ public class ImdbService(IConfiguration _configuration) : IImdbService
 
             if (result is null)
                 return Result<GetMovieByImdbResponseDto?>.Failure(
-                    new Error("404", $"Imdb ID: {imdbId} invalido"));
+                    new Error("404", $"Imdb ID: {imdbId} inválido"));
 
             return Result<GetMovieByImdbResponseDto?>.Success(result);
         }
@@ -77,7 +77,7 @@ public class ImdbService(IConfiguration _configuration) : IImdbService
             var seriesResult = allResults.Data?.TvResults.FirstOrDefault();
             if (seriesResult == null)
                 return Result<GetSeriesByImdbResponseDto?>.Failure(
-                    new Error("404", $"[{imdbId}] serie invalida"));
+                    new Error("404", $"[{imdbId}] série inválida"));
 
             var client = new HttpClient();
             var url = $"https://api.themoviedb.org/3/tv/{seriesResult.Id}";
@@ -94,7 +94,7 @@ public class ImdbService(IConfiguration _configuration) : IImdbService
 
             if (result is null)
                 return Result<GetSeriesByImdbResponseDto?>.Failure(
-                    new Error("404", $"Imdb ID: {imdbId} invalido"));
+                    new Error("404", $"Imdb ID: {imdbId} inválido"));
 
             return Result<GetSeriesByImdbResponseDto?>.Success(result);
         }
@@ -128,7 +128,7 @@ public class ImdbService(IConfiguration _configuration) : IImdbService
 
             if (result is null)
                 return Result<GetSeriesEpisodesBySeasonResponseDto?>.Failure(
-                    new Error("404", $"Imdb ID: {imdbId} invalido"));
+                    new Error("404", $"Imdb ID: {imdbId} inválido"));
 
             return Result<GetSeriesEpisodesBySeasonResponseDto?>.Success(result);
         }

--- a/XerifeTv.CMS/Modules/Integrations/Webhook/Enums/EWebhookTriggerEvent.cs
+++ b/XerifeTv.CMS/Modules/Integrations/Webhook/Enums/EWebhookTriggerEvent.cs
@@ -20,7 +20,7 @@ public static class EWebhookTriggerEventExtensions
         return eventType switch
         {
             EWebhookTriggerEvent.MOVIE_PUBLISHED => "Filme Publicado",
-            EWebhookTriggerEvent.SERIES_PUBLISHED => "Serie Publicada",
+            EWebhookTriggerEvent.SERIES_PUBLISHED => "Série Publicada",
             EWebhookTriggerEvent.CHANNEL_PUBLISHED => "Canal Publicado",
             _ => "Unknown Event"
         };
@@ -34,11 +34,11 @@ public static class EWebhookTriggerEventExtensions
                 return [
                     "{{Id}}",
                     "{{ImdbId}}",
-                    "{{Titulo}}",
+                    "{{Título}}",
                     "{{PosterUrl}}",
                     "{{BannerUrl}}",
-                    "{{Ano Lancamento}}",
-                    "{{Classificacao Indicativa}}",
+                    "{{Ano Lançamento}}",
+                    "{{Classificação Indicativa}}",
                     "{{Tempo}}"
                 ];
 
@@ -46,18 +46,18 @@ public static class EWebhookTriggerEventExtensions
                 return [
                     "{{Id}}",
                     "{{ImdbId}}",
-                    "{{Titulo}}",
+                    "{{Título}}",
                     "{{PosterUrl}}",
                     "{{BannerUrl}}",
-                    "{{Ano Lancamento}}",
-                    "{{Classificacao Indicativa}}",
+                    "{{Ano Lançamento}}",
+                    "{{Classificação Indicativa}}",
                     "{{Temporadas}}"
                 ];
 
             case EWebhookTriggerEvent.CHANNEL_PUBLISHED:
                 return [
                     "{{Id}}",
-                    "{{Titulo}}",
+                    "{{Título}}",
                     "{{LogoUrl}}"
                 ];
 
@@ -72,10 +72,13 @@ public static class EWebhookTriggerEventExtensions
         {
             payloadTemplate = payloadTemplate.Replace("{{Id}}", movieEntity!.Id);
             payloadTemplate = payloadTemplate.Replace("{{ImdbId}}", movieEntity!.ImdbId);
+            payloadTemplate = payloadTemplate.Replace("{{Título}}", movieEntity!.Title);
             payloadTemplate = payloadTemplate.Replace("{{Titulo}}", movieEntity!.Title);
             payloadTemplate = payloadTemplate.Replace("{{PosterUrl}}", movieEntity!.PosterUrl);
             payloadTemplate = payloadTemplate.Replace("{{BannerUrl}}", movieEntity!.BannerUrl);
+            payloadTemplate = payloadTemplate.Replace("{{Ano Lançamento}}", movieEntity!.ReleaseYear.ToString());
             payloadTemplate = payloadTemplate.Replace("{{Ano Lancamento}}", movieEntity!.ReleaseYear.ToString());
+            payloadTemplate = payloadTemplate.Replace("{{Classificação Indicativa}}", movieEntity!.ParentalRating.ToString());
             payloadTemplate = payloadTemplate.Replace("{{Classificacao Indicativa}}", movieEntity!.ParentalRating.ToString());
             payloadTemplate = payloadTemplate.Replace("{{Tempo}}", DateTimeHelper.ConvertSecondsToHHmm(movieEntity!.Video!.Duration));
         }
@@ -84,10 +87,13 @@ public static class EWebhookTriggerEventExtensions
         {
             payloadTemplate = payloadTemplate.Replace("{{Id}}", seriesEntity!.Id);
             payloadTemplate = payloadTemplate.Replace("{{ImdbId}}", seriesEntity!.ImdbId);
+            payloadTemplate = payloadTemplate.Replace("{{Título}}", seriesEntity!.Title);
             payloadTemplate = payloadTemplate.Replace("{{Titulo}}", seriesEntity!.Title);
             payloadTemplate = payloadTemplate.Replace("{{PosterUrl}}", seriesEntity!.PosterUrl);
             payloadTemplate = payloadTemplate.Replace("{{BannerUrl}}", seriesEntity!.BannerUrl);
+            payloadTemplate = payloadTemplate.Replace("{{Ano Lançamento}}", seriesEntity!.ReleaseYear.ToString());
             payloadTemplate = payloadTemplate.Replace("{{Ano Lancamento}}", seriesEntity!.ReleaseYear.ToString());
+            payloadTemplate = payloadTemplate.Replace("{{Classificação Indicativa}}", seriesEntity!.ParentalRating.ToString());
             payloadTemplate = payloadTemplate.Replace("{{Classificacao Indicativa}}", seriesEntity!.ParentalRating.ToString());
             payloadTemplate = payloadTemplate.Replace("{{Temporadas}}", seriesEntity!.NumberSeasons.ToString());
         }
@@ -95,6 +101,7 @@ public static class EWebhookTriggerEventExtensions
         if (eventType == EWebhookTriggerEvent.CHANNEL_PUBLISHED && entity is ChannelEntity channelEntity)
         {
             payloadTemplate = payloadTemplate.Replace("{{Id}}", channelEntity!.Id);
+            payloadTemplate = payloadTemplate.Replace("{{Título}}", channelEntity!.Title);
             payloadTemplate = payloadTemplate.Replace("{{Titulo}}", channelEntity!.Title);
             payloadTemplate = payloadTemplate.Replace("{{LogoUrl}}", channelEntity!.LogoUrl);
         }

--- a/XerifeTv.CMS/Modules/Integrations/Webhook/WebhookService.cs
+++ b/XerifeTv.CMS/Modules/Integrations/Webhook/WebhookService.cs
@@ -52,7 +52,7 @@ public sealed class WebhookService(IWebhookRepository _repository) : IWebhookSer
             var response = await _repository.GetAsync(entity.Id);
 
             if (response is null)
-                return Result<string>.Failure(new Error("404", "Webhook nao encontrado"));
+                return Result<string>.Failure(new Error("404", "Webhook não encontrado"));
 
             entity.CreateAt = response.CreateAt;
             await _repository.UpdateAsync(entity);
@@ -72,7 +72,7 @@ public sealed class WebhookService(IWebhookRepository _repository) : IWebhookSer
             var response = await _repository.GetAsync(id);
 
             if (response is null)
-                return Result<bool>.Failure(new Error("404", "Webhook nao encontrado"));
+                return Result<bool>.Failure(new Error("404", "Webhook não encontrado"));
 
             await _repository.DeleteAsync(id);
             return Result<bool>.Success(true);

--- a/XerifeTv.CMS/Modules/Media/Delivery/MediaDeliveryProfileService.cs
+++ b/XerifeTv.CMS/Modules/Media/Delivery/MediaDeliveryProfileService.cs
@@ -53,7 +53,7 @@ public class MediaDeliveryProfileService(IMediaDeliveryProfileRepository _reposi
             var response = await _repository.GetAsync(id);
 
             if (response == null)
-                return Result<GetMediaDeliveryProfileResponseDto?>.Failure(new Error("404", "Perfil de entrega de midia nao encontrado"));
+                return Result<GetMediaDeliveryProfileResponseDto?>.Failure(new Error("404", "Perfil de entrega de mídia não encontrado"));
 
             return Result<GetMediaDeliveryProfileResponseDto?>.Success(GetMediaDeliveryProfileResponseDto.FromEntity(response));
         }
@@ -71,7 +71,7 @@ public class MediaDeliveryProfileService(IMediaDeliveryProfileRepository _reposi
             var response = await _repository.GetByNameAsync(name, isIncludeDisabled);
 
             if (response == null)
-                return Result<GetMediaDeliveryProfileResponseDto?>.Failure(new Error("404", "Perfil de entrega de midia nao encontrado"));
+                return Result<GetMediaDeliveryProfileResponseDto?>.Failure(new Error("404", "Perfil de entrega de mídia não encontrado"));
 
             return Result<GetMediaDeliveryProfileResponseDto?>.Success(GetMediaDeliveryProfileResponseDto.FromEntity(response));
         }
@@ -106,7 +106,7 @@ public class MediaDeliveryProfileService(IMediaDeliveryProfileRepository _reposi
             var response = await _repository.GetAsync(dto.Id);
 
             if (response == null)
-                return Result<string>.Failure(new Error("404", "Perfil de entrega de midia nao encontrado"));
+                return Result<string>.Failure(new Error("404", "Perfil de entrega de mídia não encontrado"));
 
             entity.CreateAt = response.CreateAt;
             await _repository.UpdateAsync(entity);
@@ -126,7 +126,7 @@ public class MediaDeliveryProfileService(IMediaDeliveryProfileRepository _reposi
             var response = await _repository.GetAsync(id);
 
             if (response == null)
-                return Result<bool>.Failure(new Error("404", "Perfil de entrega de midia nao encontrado"));
+                return Result<bool>.Failure(new Error("404", "Perfil de entrega de mídia não encontrado"));
 
             await _repository.DeleteAsync(id);
             return Result<bool>.Success(true);

--- a/XerifeTv.CMS/Modules/Movie/Dtos/Response/SpreadsheetMovieResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Movie/Dtos/Response/SpreadsheetMovieResponseDto.cs
@@ -34,18 +34,18 @@ public sealed class SpreadsheetMovieResponseDto
         ];
 
         if (requiredValues.Any(string.IsNullOrEmpty))
-            throw new SpreadsheetInvalidException($"[{imdbId}] algum campo obrigatorio esta vazio");
+            throw new SpreadsheetInvalidException($"[{imdbId}] algum campo obrigatório está vazio");
 
         if (!int.TryParse(parentalRating, out var parentalRatingResult))
-            throw new SpreadsheetInvalidException($"[{imdbId}] classificacao indicativa em formato invalido");
+            throw new SpreadsheetInvalidException($"[{imdbId}] classificação indicativa em formato inválido");
 
         if (!ParentalRatingHelper.ParentalRatingList.Contains(parentalRatingResult))
-            throw new SpreadsheetInvalidException($"[{imdbId}] classificacao indicativa invalida");
+            throw new SpreadsheetInvalidException($"[{imdbId}] classificação indicativa inválida");
 
         if (!string.IsNullOrWhiteSpace(videoStreamFormat)
             && !StreamFormatsHelper.Streaming.Contains(videoStreamFormat)
             && !StreamFormatsHelper.Vod.Contains(videoStreamFormat))
-            throw new SpreadsheetInvalidException($"[{imdbId}] stream format invalido");
+            throw new SpreadsheetInvalidException($"[{imdbId}] stream format inválido");
 
         var hasMediaDeliveryProfile =
             !string.IsNullOrWhiteSpace(mediaDeliveryProfileName) &&
@@ -56,7 +56,7 @@ public sealed class SpreadsheetMovieResponseDto
             !string.IsNullOrWhiteSpace(videoStreamFormat);
 
         if (!hasMediaDeliveryProfile && !hasFixedVideo)
-            throw new SpreadsheetInvalidException( $"[{imdbId}] obrigatorio informar Media Delivery Profile/Media Path ou URL Video Fixed/Stream Format");
+            throw new SpreadsheetInvalidException( $"[{imdbId}] obrigatório informar Media Delivery Profile/Media Path ou URL Video Fixed/Stream Format");
 
         return new SpreadsheetMovieResponseDto
         {

--- a/XerifeTv.CMS/Modules/Movie/Importers/MoviesSpreadsheetImporter.cs
+++ b/XerifeTv.CMS/Modules/Movie/Importers/MoviesSpreadsheetImporter.cs
@@ -37,7 +37,7 @@ public class MoviesSpreadsheetImporter(
 
 		if (response == null)
 			return Result<ImportSpreadsheetResponseDto>.Failure(
-			  new Error("400", $"Import Id {importId} nao encontrado"));
+			  new Error("400", $"Import Id {importId} não encontrado"));
 
 		await Task.Delay(500);
 		return Result<ImportSpreadsheetResponseDto>.Success(response);

--- a/XerifeTv.CMS/Modules/Movie/MovieService.cs
+++ b/XerifeTv.CMS/Modules/Movie/MovieService.cs
@@ -45,7 +45,7 @@ public sealed class MovieService(
 
             if (response is null)
                 return Result<GetMovieResponseDto?>
-                  .Failure(new Error("404", "Conteudo nao encontrado"));
+                  .Failure(new Error("404", "Conteúdo não encontrado"));
 
             return Result<GetMovieResponseDto?>
               .Success(GetMovieResponseDto.FromEntity(response));
@@ -65,7 +65,7 @@ public sealed class MovieService(
 
             if (response is null)
                 return Result<GetMovieResponseDto?>
-                  .Failure(new Error("404", "Conteudo nao encontrado"));
+                  .Failure(new Error("404", "Conteúdo não encontrado"));
 
             return Result<GetMovieResponseDto?>
               .Success(GetMovieResponseDto.FromEntity(response));
@@ -86,7 +86,7 @@ public sealed class MovieService(
 
             if (!await imdbIdSpec.IsSatisfiedByAsync(entity))
                 return Result<string>.Failure(
-                  new Error("409", $"Filme nao cadastrado. Imdb ID {entity.ImdbId} duplicado"));
+                  new Error("409", $"Filme não cadastrado. Imdb ID {entity.ImdbId} duplicado"));
 
             var response = await _repository.CreateAsync(entity);
 
@@ -110,13 +110,13 @@ public sealed class MovieService(
             var response = await _repository.GetAsync(entity.Id);
 
             if (response is null)
-                return Result<string>.Failure(new Error("404", "Conteudo nao encontrado"));
+                return Result<string>.Failure(new Error("404", "Conteúdo não encontrado"));
 
             var imdbIdSpec = new UniqueImdbIdSpecification(_repository);
 
             if (!await imdbIdSpec.IsSatisfiedByAsync(entity))
                 return Result<string>.Failure(
-                  new Error("409", $"Filme nao atualizado. Imdb ID {entity.ImdbId} duplicado"));
+                  new Error("409", $"Filme não atualizado. Imdb ID {entity.ImdbId} duplicado"));
 
             entity.CreateAt = response.CreateAt;
             await _repository.UpdateAsync(entity);
@@ -138,7 +138,7 @@ public sealed class MovieService(
             var response = await _repository.GetAsync(id);
 
             if (response is null)
-                return Result<bool>.Failure(new Error("404", "Conteudo nao encontrado"));
+                return Result<bool>.Failure(new Error("404", "Conteúdo não encontrado"));
 
             await _repository.DeleteAsync(id);
             await _backgroundJobQueueService.AddJobInQueueAsync(ECalculateCategoryDistributionJobQueueType.MOVIES);

--- a/XerifeTv.CMS/Modules/Series/Dtos/Response/SpreadsheetEpisodeResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Series/Dtos/Response/SpreadsheetEpisodeResponseDto.cs
@@ -40,21 +40,21 @@ public sealed class SpreadsheetEpisodeResponseDto
 		];
 
 		if (requiredValues.Any(string.IsNullOrEmpty))
-			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] algum campo obrigatorio esta vazio");
+			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] algum campo obrigatório está vazio");
 
 		if (!int.TryParse(season, out var seasonResult))
-			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] season em formato invalido");
+			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] season em formato inválido");
 
 		if (!int.TryParse(episode, out var episodeResult))
-			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] numero de episodio em formato invalido");
+			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] número de episódio em formato inválido");
 
 		if (!string.IsNullOrWhiteSpace(videoStreamFormat)
             && !StreamFormatsHelper.Streaming.Contains(videoStreamFormat)
 			&& !StreamFormatsHelper.Vod.Contains(videoStreamFormat))
-			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] stream format invalido");
+			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] stream format inválido");
 
 		if (!long.TryParse(videoDuration, out var videoDurationResult))
-			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] duracao de video em formato invalido");
+			throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] duração de vídeo em formato inválido");
 
         var hasMediaDeliveryProfile =
             !string.IsNullOrWhiteSpace(mediaDeliveryProfileName) &&
@@ -65,7 +65,7 @@ public sealed class SpreadsheetEpisodeResponseDto
             !string.IsNullOrWhiteSpace(videoStreamFormat);
 
         if (!hasMediaDeliveryProfile && !hasFixedVideo)
-            throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] obrigatorio informar Media Delivery Profile/Media Path ou URL Video Fixed/Stream Format");
+            throw new SpreadsheetInvalidException($"[{seriesImdbId}:S{season}E{episode}] obrigatório informar Media Delivery Profile/Media Path ou URL Video Fixed/Stream Format");
 
 
         return new SpreadsheetEpisodeResponseDto

--- a/XerifeTv.CMS/Modules/Series/Dtos/Response/SpreadsheetSeriesResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Series/Dtos/Response/SpreadsheetSeriesResponseDto.cs
@@ -23,13 +23,13 @@ public sealed class SpreadsheetSeriesResponseDto
         List<string?> requiredValues = [imdbId, title, parentalRating];
 
         if (requiredValues.Any(string.IsNullOrEmpty))
-            throw new SpreadsheetInvalidException($"[{imdbId}] algum campo obrigatorio esta vazio");
+            throw new SpreadsheetInvalidException($"[{imdbId}] algum campo obrigatório está vazio");
 
         if (!int.TryParse(parentalRating, out var parentalRatingResult))
-            throw new SpreadsheetInvalidException($"[{imdbId}] classificacao indicativa em formato invalido");
+            throw new SpreadsheetInvalidException($"[{imdbId}] classificação indicativa em formato inválido");
 
         if (!ParentalRatingHelper.ParentalRatingList.Contains(parentalRatingResult))
-            throw new SpreadsheetInvalidException($"[{imdbId}] classificacao indicativa invalida");
+            throw new SpreadsheetInvalidException($"[{imdbId}] classificação indicativa inválida");
 
         return new SpreadsheetSeriesResponseDto
         {

--- a/XerifeTv.CMS/Modules/Series/Importers/EpisodesImdbImporter.cs
+++ b/XerifeTv.CMS/Modules/Series/Importers/EpisodesImdbImporter.cs
@@ -30,7 +30,7 @@ public class EpisodesImdbImporter(
 
 		if (response == null)
 			return Result<ImportEpisodesResponseDto>.Failure(
-			  new Error("400", $"Import Id {importId} nao encontrado"));
+			  new Error("400", $"Import Id {importId} não encontrado"));
 
 		await Task.Delay(500);
 		return Result<ImportEpisodesResponseDto>.Success(response);

--- a/XerifeTv.CMS/Modules/Series/Importers/SeriesSpreadsheetImporter.cs
+++ b/XerifeTv.CMS/Modules/Series/Importers/SeriesSpreadsheetImporter.cs
@@ -37,7 +37,7 @@ public class SeriesSpreadsheetImporter(
 
         if (response == null)
             return Result<ImportSpreadsheetResponseDto>.Failure(
-              new Error("400", $"Import Id {importId} nao encontrado"));
+              new Error("400", $"Import Id {importId} não encontrado"));
 
         await Task.Delay(500);
         return Result<ImportSpreadsheetResponseDto>.Success(response);

--- a/XerifeTv.CMS/Modules/Series/SeriesService.cs
+++ b/XerifeTv.CMS/Modules/Series/SeriesService.cs
@@ -15,7 +15,6 @@ namespace XerifeTv.CMS.Modules.Series;
 
 public class SeriesService(
     ISeriesRepository _repository,
-    IWebhookService _webhookService,
     IFranchiseService _franchiseService,
     IBackgroundJobQueueService _backgroundJobQueueService,
     IConfiguration _configuration) : ISeriesService
@@ -48,7 +47,7 @@ public class SeriesService(
 
             if (response is null)
                 return Result<GetSeriesResponseDto?>
-                  .Failure(new Error("404", "Conteudo nao encontrado"));
+                  .Failure(new Error("404", "Conteúdo não encontrado"));
 
             return Result<GetSeriesResponseDto?>
               .Success(GetSeriesResponseDto.FromEntity(response));
@@ -68,7 +67,7 @@ public class SeriesService(
 
             if (response is null)
                 return Result<GetSeriesResponseDto?>
-                  .Failure(new Error("404", "Conteudo nao encontrado"));
+                  .Failure(new Error("404", "Conteúdo não encontrado"));
 
             return Result<GetSeriesResponseDto?>
               .Success(GetSeriesResponseDto.FromEntity(response));
@@ -89,7 +88,7 @@ public class SeriesService(
 
             if (!await imdbIdSpec.IsSatisfiedByAsync(entity))
                 return Result<string>.Failure(
-                  new Error("409", $"Serie nao cadastrada. Imdb ID {entity.ImdbId} duplicado"));
+                  new Error("409", $"Série não cadastrada. Imdb ID {entity.ImdbId} duplicado"));
 
             var response = await _repository.CreateAsync(entity);
             await _backgroundJobQueueService.AddJobInQueueAsync(ECalculateCategoryDistributionJobQueueType.SERIES);
@@ -112,13 +111,13 @@ public class SeriesService(
             var response = await _repository.GetAsync(entity.Id);
 
             if (response is null)
-                return Result<string>.Failure(new Error("404", "Conteudo nao encontrado"));
+                return Result<string>.Failure(new Error("404", "Conteúdo não encontrado"));
 
             var imdbIdSpec = new UniqueImdbIdSpecification(_repository);
 
             if (!await imdbIdSpec.IsSatisfiedByAsync(entity))
                 return Result<string>.Failure(
-                  new Error("409", $"Serie nao atualizada. Imdb ID {entity.ImdbId} duplicado"));
+                  new Error("409", $"Série não atualizada. Imdb ID {entity.ImdbId} duplicado"));
 
             await _repository.UpdateAsync(entity);
             await _backgroundJobQueueService.AddJobInQueueAsync(ECalculateCategoryDistributionJobQueueType.SERIES);
@@ -139,7 +138,7 @@ public class SeriesService(
             var response = await _repository.GetAsync(id);
 
             if (response is null)
-                return Result<bool>.Failure(new Error("404", "Conteudo nao encontrado"));
+                return Result<bool>.Failure(new Error("404", "Conteúdo não encontrado"));
 
             await _repository.DeleteAsync(id);
             await _backgroundJobQueueService.AddJobInQueueAsync(ECalculateCategoryDistributionJobQueueType.SERIES);
@@ -192,7 +191,7 @@ public class SeriesService(
 
             if (response is null)
                 return Result<GetEpisodesResponseDto>
-                  .Failure(new Error("404", "Conteudo nao encontrado"));
+                  .Failure(new Error("404", "Conteúdo não encontrado"));
 
             var result = GetEpisodesResponseDto.FromEntity(response);
             result.SetUrlResolverPathEpisodes(_configuration["SecuritySettings:ContentEncryptionKey"]!);
@@ -213,7 +212,7 @@ public class SeriesService(
             var seriesResponse = await _repository.GetAsync(dto.SerieId);
 
             if (seriesResponse is null)
-                return Result<string>.Failure(new Error("404", "Conteudo nao encontrado"));
+                return Result<string>.Failure(new Error("404", "Conteúdo não encontrado"));
 
             var episodesResult = await GetEpisodesBySeasonAsync(dto.SerieId, dto.Season, includeDisabled: true);
             if (episodesResult.IsFailure)
@@ -224,7 +223,7 @@ public class SeriesService(
 
             if (existingEpisode)
                 return Result<string>.Failure(
-                    new Error("409", $"Episodio nao cadastrado. [{seriesResponse.ImdbId}|T{dto.Season}:EP{dto.Number}] duplicado"));
+                    new Error("409", $"Episódio não cadastrado. [{seriesResponse.ImdbId}|T{dto.Season}:EP{dto.Number}] duplicado"));
 
             await _repository.CreateEpisodeAsync(seriesResponse.Id, dto.ToEntity());
 
@@ -244,7 +243,7 @@ public class SeriesService(
             var seriesResponse = await _repository.GetAsync(dto.SerieId);
 
             if (seriesResponse is null)
-                return Result<string>.Failure(new Error("404", "Conteudo nao encontrado"));
+                return Result<string>.Failure(new Error("404", "Conteúdo não encontrado"));
 
             var episodesResult = await GetEpisodesBySeasonAsync(dto.SerieId, dto.Season, includeDisabled: true);
             if (episodesResult.IsFailure)
@@ -255,7 +254,7 @@ public class SeriesService(
 
             if (existingEpisode)
                 return Result<string>.Failure(
-                    new Error("409", $"Episodio nao atualizado. [{seriesResponse.ImdbId}|T{dto.Season}:EP{dto.Number}] duplicado"));
+                    new Error("409", $"Episódio não atualizado. [{seriesResponse.ImdbId}|T{dto.Season}:EP{dto.Number}] duplicado"));
 
             await _repository.UpdateEpisodeAsync(seriesResponse.Id, dto.ToEntity());
 
@@ -275,7 +274,7 @@ public class SeriesService(
             var response = await _repository.GetAsync(serieId);
 
             if (response is null)
-                return Result<bool>.Failure(new Error("404", "Serie nao encontrada"));
+                return Result<bool>.Failure(new Error("404", "Série não encontrada"));
 
             await _repository.DeleteEpisodeAsync(serieId, id);
 

--- a/XerifeTv.CMS/Modules/User/UserEntity.cs
+++ b/XerifeTv.CMS/Modules/User/UserEntity.cs
@@ -15,7 +15,7 @@ public class UserEntity : BaseEntity
         set
         {
             if (!RegexHelper.IsValidEmail(value))
-                throw new ArgumentException("Email invalido");
+                throw new ArgumentException("Email inválido");
 
             _email = value;
         }

--- a/XerifeTv.CMS/Modules/User/UserService.cs
+++ b/XerifeTv.CMS/Modules/User/UserService.cs
@@ -41,7 +41,7 @@ public sealed class UserService(
 
 			if (response == null)
 				return Result<GetUserResponseDto?>.Failure(
-				  new Error("404", "Usuario nao encontrado"));
+				  new Error("404", "Usuário não encontrado"));
 
 			return Result<GetUserResponseDto?>.Success(GetUserResponseDto.FromEntity(response));
 		}
@@ -60,7 +60,7 @@ public sealed class UserService(
 
             if (response == null)
                 return Result<GetUserResponseDto?>.Failure(
-                  new Error("404", "Usuario nao encontrado"));
+                  new Error("404", "Usuário não encontrado"));
 
             return Result<GetUserResponseDto?>.Success(GetUserResponseDto.FromEntity(response));
         }
@@ -80,10 +80,10 @@ public sealed class UserService(
 			var usernameSpec = new UniqueUsernameSpecification(_repository);
 
 			if (!await emailSpec.IsSatisfiedByAsync(entity))
-				return Result<string>.Failure(new Error("409", "Email ja esta em uso"));
+				return Result<string>.Failure(new Error("409", "Email já está em uso"));
 
 			if (!await usernameSpec.IsSatisfiedByAsync(entity))
-				return Result<string>.Failure(new Error("409", "Username ja esta em uso"));
+				return Result<string>.Failure(new Error("409", "Username já está em uso"));
 
 			entity.Password = _hashPassword.Encrypt(dto.Password);
 			var response = await _repository.CreateAsync(entity);
@@ -108,16 +108,16 @@ public sealed class UserService(
 			var user = await _repository.GetAsync(dto.Id);
 
 			if (user == null)
-				return Result<string>.Failure(new Error("404", "Usuario nao encontrado"));
+				return Result<string>.Failure(new Error("404", "Usuário não encontrado"));
 
 			var emailSpec = new UniqueEmailSpecification(_repository);
 			var usernameSpec = new UniqueUsernameSpecification(_repository);
 
 			if (!await emailSpec.IsSatisfiedByAsync(dto.ToEntity()))
-				return Result<string>.Failure(new Error("409", "Email ja esta em uso"));
+				return Result<string>.Failure(new Error("409", "Email já está em uso"));
 
 			if (!await usernameSpec.IsSatisfiedByAsync(dto.ToEntity()))
-				return Result<string>.Failure(new Error("409", "Username ja esta em uso"));
+				return Result<string>.Failure(new Error("409", "Username já está em uso"));
 
 			if (dto.Blocked == false && user.Blocked)
 				user.FailedLoginAttempts = 0;
@@ -149,7 +149,7 @@ public sealed class UserService(
 			var user = await _repository.GetAsync(dto.Id);
 
 			if (user is null)
-				return Result<string>.Failure(new Error("404", "Usuario nao encontrado"));
+				return Result<string>.Failure(new Error("404", "Usuário não encontrado"));
 
 			var isPasswordCorrect = _hashPassword.Verify(dto.OldPassword, user.Password);
 
@@ -176,7 +176,7 @@ public sealed class UserService(
 
 			if (user is null)
 				return Result<ValidateResetPasswordGuidResponseDto>.Failure(
-					new Error("404", "Usuario nao encontrado"));
+					new Error("404", "Usuário não encontrado"));
 
 			user.Password = _hashPassword.Encrypt(dto.Password);
 			user.ResetPasswordGuid = Guid.Empty;
@@ -199,10 +199,10 @@ public sealed class UserService(
 			var response = await _repository.GetAsync(id);
 
 			if (response is null)
-				return Result<bool>.Failure(new Error("404", "Usuario nao encontrado"));
+				return Result<bool>.Failure(new Error("404", "Usuário não encontrado"));
 
 			if (response.Role == Enums.EUserRole.ADMIN)
-				return Result<bool>.Failure(new Error("403", "Usuario nao pode ser deletado"));
+				return Result<bool>.Failure(new Error("403", "Usuário não pode ser deletado"));
 
 			await _repository.DeleteAsync(id);
 			return Result<bool>.Success(true);
@@ -221,7 +221,7 @@ public sealed class UserService(
 			var user = await _repository.GetByEmailAsync(email);
 
 			if (user is null)
-				return Result<string>.Failure(new Error("404", "Email nao encontrado"));
+				return Result<string>.Failure(new Error("404", "Email não encontrado"));
 
 			user.ResetPasswordGuid = Guid.NewGuid();
 			user.ResetPasswordGuidExpires = DateTimeOffset.UtcNow.AddMinutes(10);
@@ -245,7 +245,7 @@ public sealed class UserService(
 			var user = await _repository.GetByResetPasswordGuidAsync(guid);
 
 			if (user is null)
-				return Result<ValidateResetPasswordGuidResponseDto>.Failure(new Error("404", "Link invalido"));
+				return Result<ValidateResetPasswordGuidResponseDto>.Failure(new Error("404", "Link inválido"));
 
 			if (user.ResetPasswordGuidExpires < DateTimeOffset.UtcNow)
 				return Result<ValidateResetPasswordGuidResponseDto>.Failure(new Error("401", "O link expirou"));
@@ -269,7 +269,7 @@ public sealed class UserService(
             var user = await _repository.GetAsync(userId);
 
             if (user == null)
-                return Result<bool>.Failure(new Error("404", "Usuario nao encontrado"));
+                return Result<bool>.Failure(new Error("404", "Usuário não encontrado"));
 
 			if (!_hashPassword.Verify(password, user.Password))
 			{

--- a/XerifeTv.CMS/Program.cs
+++ b/XerifeTv.CMS/Program.cs
@@ -1,5 +1,7 @@
 ﻿using Scalar.AspNetCore;
 using System.Globalization;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using XerifeTv.CMS.Shared.Database.MongoDB;
 using XerifeTv.CMS.Shared.Extensions;
 
@@ -26,6 +28,8 @@ builder.Services.Configure<DBSettings>(
 	builder.Configuration.GetSection("MongoDBConfig"));
 
 builder.Services.AddConfiguration(builder.Configuration);
+
+builder.Services.AddSingleton<HtmlEncoder>(HtmlEncoder.Create(UnicodeRanges.BasicLatin, UnicodeRanges.Latin1Supplement));
 
 var app = builder.Build();
 

--- a/XerifeTv.CMS/Views/Channels/Form.cshtml
+++ b/XerifeTv.CMS/Views/Channels/Form.cshtml
@@ -45,7 +45,7 @@
 
             <div class="row mb-3">
                 <div class="col-12 col-md-6">
-                    <label for="title" class="form-label">Titulo</label>
+                    <label for="title" class="form-label">Título</label>
                     <input type="text"
                            class="form-control"
                            id="title"

--- a/XerifeTv.CMS/Views/Channels/Index.cshtml
+++ b/XerifeTv.CMS/Views/Channels/Index.cshtml
@@ -7,7 +7,7 @@
     ViewData["Title"] = "Canais";
 
     ICollection<string[]> filters = [];
-    filters.Add([EChannelSearchFilter.TITLE.ToString().ToLower(), "Titulo"]);
+    filters.Add([EChannelSearchFilter.TITLE.ToString().ToLower(), "Título"]);
     filters.Add([EChannelSearchFilter.CATEGORY.ToString().ToLower(), "Categoria"]);
 }
 

--- a/XerifeTv.CMS/Views/Movies/Form.cshtml
+++ b/XerifeTv.CMS/Views/Movies/Form.cshtml
@@ -64,7 +64,7 @@
                 </div>
 
                 <div class="col-12 col-md-5">
-                    <label for="title" class="form-label">Titulo</label>
+                    <label for="title" class="form-label">Título</label>
                     <input type="text"
                            class="form-control"
                            id="title"

--- a/XerifeTv.CMS/Views/Movies/Index.cshtml
+++ b/XerifeTv.CMS/Views/Movies/Index.cshtml
@@ -7,7 +7,7 @@
     ViewData["Title"] = "Filmes";
 
     ICollection<string[]> filters = [];
-    filters.Add([EMovieSearchFilter.TITLE.ToString().ToLower(), "Titulo"]);
+    filters.Add([EMovieSearchFilter.TITLE.ToString().ToLower(), "Título"]);
     filters.Add([EMovieSearchFilter.CATEGORY.ToString().ToLower(), "Categoria"]);
     filters.Add([EMovieSearchFilter.RELEASE_YEAR.ToString().ToLower(), "Ano de Lançamento"]);
     filters.Add([EMovieSearchFilter.PARENTAL_RATING.ToString().ToLower(), "Classificação Indicativa"]);

--- a/XerifeTv.CMS/Views/Series/Episodes.cshtml
+++ b/XerifeTv.CMS/Views/Series/Episodes.cshtml
@@ -159,7 +159,7 @@
         $('.disabled').change(e => e.target.value = e.target.checked);
 
         function remove(id) {
-            if (!confirm('Deseja realmento excluir o episódio?')) return;
+            if (!confirm('Deseja realmente excluir o episódio?')) return;
             location.href = `/Series/DeleteEpisode?serieId=@Model?.EpisodesDto?.SerieId&id=${id}`;
         }
 

--- a/XerifeTv.CMS/Views/Series/Form.cshtml
+++ b/XerifeTv.CMS/Views/Series/Form.cshtml
@@ -62,7 +62,7 @@
                 </div>
 
                 <div class="col-12 col-md-5">
-                    <label for="title" class="form-label">Titulo</label>
+                    <label for="title" class="form-label">Título</label>
                     <input type="text"
                            class="form-control"
                            id="title"

--- a/XerifeTv.CMS/Views/Series/Index.cshtml
+++ b/XerifeTv.CMS/Views/Series/Index.cshtml
@@ -7,7 +7,7 @@
     ViewData["Title"] = "Séries";
 
     ICollection<string[]> filters = [];
-    filters.Add([ESeriesSearchFilter.TITLE.ToString().ToLower(), "Titulo"]);
+    filters.Add([ESeriesSearchFilter.TITLE.ToString().ToLower(), "Título"]);
     filters.Add([ESeriesSearchFilter.CATEGORY.ToString().ToLower(), "Categoria"]);
     filters.Add([ESeriesSearchFilter.RELEASE_YEAR.ToString().ToLower(), "Ano de Lançamento"]);
     filters.Add([ESeriesSearchFilter.PARENTAL_RATING.ToString().ToLower(), "Classificação Indicativa"]);

--- a/XerifeTv.CMS/Views/Series/_EpisodeFormModal.cshtml
+++ b/XerifeTv.CMS/Views/Series/_EpisodeFormModal.cshtml
@@ -68,7 +68,7 @@
 
                 <div class="row mb-2">
                     <div class="col-12">
-                        <label for="title" class="form-label">Titulo</label>
+                        <label for="title" class="form-label">Título</label>
                         <input type="text"
                                class="form-control"
                                id="title-@Model?.Episode?.Id"

--- a/XerifeTv.CMS/Views/Settings/Index.cshtml
+++ b/XerifeTv.CMS/Views/Settings/Index.cshtml
@@ -210,7 +210,7 @@
                                     type="button"
                                     role="tab"
                                     aria-selected="true">
-                                Perfis de Entrega de Midia
+                                Perfis de Entrega de Mídia
                             </button>
                         </li>
                     </ul>

--- a/XerifeTv.CMS/Views/Settings/_MediaDeliveryProfileFormModal.cshtml
+++ b/XerifeTv.CMS/Views/Settings/_MediaDeliveryProfileFormModal.cshtml
@@ -25,7 +25,7 @@
                 <h1 class="modal-title fs-5"
                     id="mediaDeliveryProfileFormModal-@Model?.Id-Label">
                     @(string.IsNullOrEmpty(Model?.Id) ? "Cadastrar" : "Editar")
-                    Perfil de Entrega de Midia
+                    Perfil de Entrega de Mídia
                 </h1>
 
                 <button type="button"
@@ -175,7 +175,7 @@
     });
 
     document.querySelector('.btn-delete-media-profile-@Model?.Id')?.addEventListener('click', function() {
-        if (!confirm('Deseja realmente remover este Perfil Entrega de Midia?')) return;
+        if (!confirm('Deseja realmente remover este Perfil Entrega de Mídia?')) return;
 
         location.href = '@Url.Action("Delete", "MediaDeliveryProfiles", new { id = Model?.Id })';
     });

--- a/XerifeTv.CMS/Views/Settings/_MediaDeliveryProfiles.cshtml
+++ b/XerifeTv.CMS/Views/Settings/_MediaDeliveryProfiles.cshtml
@@ -34,7 +34,7 @@
         {
             <tr>
                 <td colspan="5" class="text-center text-muted py-4">
-                    Nenhuma registro encontrado.
+                    Nenhum registro encontrado.
                 </td>
             </tr>
         }

--- a/XerifeTv.CMS/Views/Shared/_FranchiseField.cshtml
+++ b/XerifeTv.CMS/Views/Shared/_FranchiseField.cshtml
@@ -300,7 +300,7 @@
                 bootstrap.Modal.getOrCreateInstance(franchiseModalElement).hide();
             }
             catch (xhr) {
-                alert(xhr?.responseText || 'Nao foi possivel cadastrar a franquia.');
+                alert(xhr?.responseText || 'Não foi possível cadastrar a franquia.');
             }
         });
 
@@ -326,7 +326,7 @@
                 await loadFranchises('');
             }
             catch (xhr) {
-                alert(xhr?.responseText || 'Nao foi possivel excluir a franquia.');
+                alert(xhr?.responseText || 'Não foi possível excluir a franquia.');
             }
         });
     })();

--- a/XerifeTv.CMS/Views/Shared/_VideoSetting.cshtml
+++ b/XerifeTv.CMS/Views/Shared/_VideoSetting.cshtml
@@ -17,7 +17,7 @@
 
     <div id="@($"{prefix}_video-direct-section")" class="row mb-3 @(isDeliverySelected ? "d-none" : "")">
         <div class="col-6">
-            <label for="@($"{prefix}_videoUrl")" class="form-label">Video (URL)</label>
+            <label for="@($"{prefix}_videoUrl")" class="form-label">Vídeo (URL)</label>
             <input type="text"
                    class="form-control"
                    id="@($"{prefix}_videoUrl")"

--- a/XerifeTv.CMS/Views/Users/UserUnauthorized.cshtml
+++ b/XerifeTv.CMS/Views/Users/UserUnauthorized.cshtml
@@ -7,7 +7,7 @@
       style="height: 24rem; border-radius: 0.25rem;" />
 
     <div class="w-75 text-center">
-      <span class="display-6 fw-bold">Você não tem permissão para acessar essa pagina!</span>
+      <span class="display-6 fw-bold">Você não tem permissão para acessar essa página!</span>
     </div>
 
     <button class="btn btn-primary" onclick="history.back()">Voltar</button>


### PR DESCRIPTION
Review and correct user-facing text throughout the application, including spelling, accentuation, and proper Portuguese phrasing in messages, labels, placeholders, confirmations, and validation messages.

- Fix spelling/accentuation in webhook payloads, job names, and service response strings for consistency across the codebase.
- Apply minor layout adjustments in .cshtml files.
- Configure HtmlEncoder to support Unicode, so accented characters (ç, ã, etc.) render correctly instead of being HTML-entity-encoded.

No business logic changes.