### PR TITLE
feat(series): add IMDB episode import cancellation support

### DIFF
--- a/XerifeTv.CMS/Controllers/SeriesController.cs
+++ b/XerifeTv.CMS/Controllers/SeriesController.cs
@@ -339,5 +339,16 @@ public class SeriesController(
 
         return BadRequest(response.Error.Description ?? string.Empty);
     }
+
+    [Authorize(Roles = "admin, common")]
+    [HttpPost]
+    public async Task<IActionResult> CancelImport(CancelImportEpisodesRequestDto dto)
+    {
+        var response = await episodesImporter.CancelImportAsync(dto.ImportId);
+
+        if (response.IsSuccess) return Ok(response.Data);
+
+        return BadRequest(response.Error.Description ?? string.Empty);
+    }
 }
 

--- a/XerifeTv.CMS/Modules/Series/Dtos/Request/CancelImportEpisodesRequestDto.cs
+++ b/XerifeTv.CMS/Modules/Series/Dtos/Request/CancelImportEpisodesRequestDto.cs
@@ -1,0 +1,3 @@
+﻿namespace XerifeTv.CMS.Modules.Series.Dtos.Request;
+
+public record CancelImportEpisodesRequestDto(string ImportId);

--- a/XerifeTv.CMS/Modules/Series/Dtos/Response/ImportEpisodesResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Series/Dtos/Response/ImportEpisodesResponseDto.cs
@@ -4,4 +4,5 @@ public record ImportEpisodesResponseDto(
 	int TotalItemsCount,
 	int ImportedCount,
 	int ProgressCount,
-	int ProcessedCount);
+	int ProcessedCount, 
+	bool IsCancelled = false);

--- a/XerifeTv.CMS/Modules/Series/Importers/EpisodesImdbImporter.cs
+++ b/XerifeTv.CMS/Modules/Series/Importers/EpisodesImdbImporter.cs
@@ -8,101 +8,132 @@ using XerifeTv.CMS.Modules.Series.Interfaces;
 namespace XerifeTv.CMS.Modules.Series.Importers;
 
 public class EpisodesImdbImporter(
-	ISeriesService service,
-	IImdbService imdbService,
-	ICacheService cacheService) : IEpisodesImporter
+    ISeriesService service,
+    IImdbService imdbService,
+    ICacheService cacheService) : IEpisodesImporter
 {
-	public async Task<Result<string>> ImportAsync(string seriesId)
-	{
-		var importId = Guid.NewGuid().ToString();
-		var emptyDto = new ImportEpisodesResponseDto(0, 0, 0, 0);
-		cacheService.SetValue<ImportEpisodesResponseDto>(importId, emptyDto);
+    public async Task<Result<string>> ImportAsync(string seriesId)
+    {
+        var importId = Guid.NewGuid().ToString();
+        var emptyDto = new ImportEpisodesResponseDto(0, 0, 0, 0);
+        cacheService.SetValue<ImportEpisodesResponseDto>(importId, emptyDto);
 
-		_ = HandleImportAsync(seriesId, importId);
+        _ = HandleImportAsync(seriesId, importId);
 
-		await Task.Delay(300);
-		return Result<string>.Success(importId);
-	}
+        await Task.Delay(300);
+        return Result<string>.Success(importId);
+    }
 
-	public async Task<Result<ImportEpisodesResponseDto>> MonitorImportAsync(string importId)
-	{
-		var response = cacheService.GetValue<ImportEpisodesResponseDto>(importId);
+    public async Task<Result<ImportEpisodesResponseDto>> MonitorImportAsync(string importId)
+    {
+        var response = cacheService.GetValue<ImportEpisodesResponseDto>(importId);
 
-		if (response == null)
-			return Result<ImportEpisodesResponseDto>.Failure(
-			  new Error("400", $"Import Id {importId} não encontrado"));
+        if (response == null)
+            return Result<ImportEpisodesResponseDto>.Failure(
+              new Error("400", $"Import Id {importId} não encontrado"));
 
-		await Task.Delay(500);
-		return Result<ImportEpisodesResponseDto>.Success(response);
-	}
+        return Result<ImportEpisodesResponseDto>.Success(response);
+    }
 
-	private async Task HandleImportAsync(string seriesId, string importId)
-	{
-		try
-		{
-			var seriesResult = await service.GetAsync(seriesId);
-			if (seriesResult.IsFailure) throw new Exception(seriesResult.Error.Description);
+    public async Task<Result<bool>> CancelImportAsync(string importId)
+    {
+        var response = cacheService.GetValue<ImportEpisodesResponseDto>(importId);
 
-			var seriesImdbResult = await imdbService.GetSeriesByImdbIdAsync(seriesResult.Data?.ImdbId ?? string.Empty);
-			if (seriesImdbResult.IsFailure) throw new Exception(seriesImdbResult.Error.Description);
+        if (response == null)
+            return Result<bool>.Failure(new Error("400", $"Import Id {importId} não encontrado"));
 
-			var seriesEpisodesImdbCount = seriesImdbResult.Data?.NumberEpisodes ?? 0;
-			var createdEpisodesCount = 0;
-			var episodeCreationAttemptsCount = 0;
+        cacheService.SetValue<bool>($"cancelled_{importId}", true);
+        return Result<bool>.Success(true);
+    }
+
+    private async Task HandleImportAsync(string seriesId, string importId)
+    {
+        try
+        {
+            var seriesResult = await service.GetAsync(seriesId);
+            if (seriesResult.IsFailure) throw new Exception(seriesResult.Error.Description);
+
+            var seriesImdbResult = await imdbService.GetSeriesByImdbIdAsync(seriesResult.Data?.ImdbId ?? string.Empty);
+            if (seriesImdbResult.IsFailure) throw new Exception(seriesImdbResult.Error.Description);
+
+            var seriesEpisodesImdbCount = seriesImdbResult.Data?.NumberEpisodes ?? 0;
+            var createdEpisodesCount = 0;
+            var episodeCreationAttemptsCount = 0;
 
             void UpdateProgress()
-			{
-				var progressCount = (int)(((float)episodeCreationAttemptsCount / seriesEpisodesImdbCount) * 100);
-				var _dto = new ImportEpisodesResponseDto(
-					TotalItemsCount: seriesEpisodesImdbCount,
-					ImportedCount: createdEpisodesCount,
-					ProgressCount: progressCount,
-					ProcessedCount: episodeCreationAttemptsCount);
+            {
+                bool importCancelled = cacheService.GetValue<bool>($"cancelled_{importId}") == true;
 
-				cacheService.SetValue<ImportEpisodesResponseDto>(importId, _dto);
-			}
+                var progressCount = (int)(((float)episodeCreationAttemptsCount / seriesEpisodesImdbCount) * 100);
+                var _dto = new ImportEpisodesResponseDto(
+                    TotalItemsCount: seriesEpisodesImdbCount,
+                    ImportedCount: createdEpisodesCount,
+                    ProgressCount: progressCount,
+                    ProcessedCount: episodeCreationAttemptsCount,
+                    IsCancelled: importCancelled);
 
-			for (int i = 1; i <= seriesImdbResult?.Data?.NumberSeasons; i++)
-			{
-				var result = await imdbService.GetSeriesEpisodesBySeasonAsync(seriesResult.Data!.ImdbId, i);
-				if (result.IsFailure || result.Data == null) continue;
+                cacheService.SetValue<ImportEpisodesResponseDto>(importId, _dto);
 
-				foreach (var episode in result.Data.Episodes)
-				{
-					var newEpisodeResult = await service.CreateEpisodeAsync(new CreateEpisodeRequestDto
-					{
-						SerieId = seriesResult.Data.Id,
-						Title = episode.Name,
-						BannerUrl = episode.BannerUrl,
-						Number = episode.EpisodeNumber,
-						Season = episode.SeasonNumber,
-						VideoDuration = episode.DurationInSeconds,
-						IsDisabled = true
-					});
+                if (importCancelled)
+                    throw new OperationCanceledException("Importação cancelada pelo usuário");
+            }
 
-					if (newEpisodeResult.IsSuccess) createdEpisodesCount++;
+            for (int i = 1; i <= seriesImdbResult?.Data?.NumberSeasons; i++)
+            {
+                var result = await imdbService.GetSeriesEpisodesBySeasonAsync(seriesResult.Data!.ImdbId, i);
+                if (result.IsFailure || result.Data == null) continue;
 
-					episodeCreationAttemptsCount++;
-					UpdateProgress();
-				}
-			}
-		}
-		catch (Exception)
-		{
-			var monitorResponse = await MonitorImportAsync(importId);
+                foreach (var episode in result.Data.Episodes)
+                {
+                    var newEpisodeResult = await service.CreateEpisodeAsync(new CreateEpisodeRequestDto
+                    {
+                        SerieId = seriesResult.Data.Id,
+                        Title = episode.Name,
+                        BannerUrl = episode.BannerUrl,
+                        Number = episode.EpisodeNumber,
+                        Season = episode.SeasonNumber,
+                        VideoDuration = episode.DurationInSeconds,
+                        IsDisabled = true
+                    });
 
-			if (monitorResponse.IsSuccess)
-			{
-				var currentProgress = monitorResponse.Data;
-				var _newDto = new ImportEpisodesResponseDto(
-					TotalItemsCount: currentProgress?.TotalItemsCount ?? 0,
-					ImportedCount: currentProgress?.ImportedCount ?? 0,
-					ProcessedCount: currentProgress?.ProcessedCount ?? 0,
-					ProgressCount: 100);
+                    if (newEpisodeResult.IsSuccess) createdEpisodesCount++;
 
-				cacheService.SetValue<ImportEpisodesResponseDto>(importId, _newDto);
-			}
-		}
-	}
+                    episodeCreationAttemptsCount++;
+                    UpdateProgress();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            var monitorResponse = await MonitorImportAsync(importId);
+
+            if (monitorResponse.IsSuccess)
+            {
+                var currentProgress = monitorResponse.Data ?? new ImportEpisodesResponseDto(0, 0, 0, 0);
+                var progress = currentProgress with
+                {
+                    ProgressCount = 100,
+                    IsCancelled = true
+                };
+
+                cacheService.SetValue<ImportEpisodesResponseDto>(importId, progress);
+            }
+        }
+        catch (Exception)
+        {
+            var monitorResponse = await MonitorImportAsync(importId);
+
+            if (monitorResponse.IsSuccess)
+            {
+                var currentProgress = monitorResponse.Data ?? new ImportEpisodesResponseDto(0, 0, 0, 0);
+                var progress = currentProgress with
+                {
+                    ProgressCount = 100
+                };
+
+                cacheService.SetValue<ImportEpisodesResponseDto>(importId, progress);
+            }
+        }
+    }
 }
 

--- a/XerifeTv.CMS/Modules/Series/Interfaces/IEpisodesImporter.cs
+++ b/XerifeTv.CMS/Modules/Series/Interfaces/IEpisodesImporter.cs
@@ -6,5 +6,6 @@ namespace XerifeTv.CMS.Modules.Series.Interfaces;
 public interface IEpisodesImporter
 {
     Task<Result<string>> ImportAsync(string seriesId);
-	Task<Result<ImportEpisodesResponseDto>> MonitorImportAsync(string importId);
+    Task<Result<ImportEpisodesResponseDto>> MonitorImportAsync(string importId);
+    Task<Result<bool>> CancelImportAsync(string importId);
 }

--- a/XerifeTv.CMS/Views/Series/Episodes.cshtml
+++ b/XerifeTv.CMS/Views/Series/Episodes.cshtml
@@ -209,6 +209,7 @@
             }
 
             $('#importEpisodesProgressModal').modal('show');
+            $('.close-modal').hide();
 
             var monitorProgressInterval = 0;
 
@@ -224,15 +225,53 @@
 
                 var importId = await response.text();
 
+                $('#btn-cancel-import').click(async function() {
+                    if (!confirm('Deseja realmente cancelar a importação?')) return;
+
+                    $(this).text('Cancelando...')
+                    $(this).attr('disabled', true);
+
+                    const cancelFormData = new FormData();
+                    cancelFormData.append('importId', importId);
+
+                    await fetch(`/Series/CancelImport`, {
+                        method: 'POST',
+                        body: cancelFormData
+                    });
+                });
+
                 // monitor progress records
                 monitorProgressInterval = setInterval(async () => {
                     var monitorResponse = await fetch(`/Series/MonitorImdbEpisodesImport?importId=${importId}`);
-                    const { importedCount, progressCount } = await monitorResponse.json();
+                    const { importedCount, progressCount, isCancelled } = await monitorResponse.json();
 
                     if (progressCount == 0) return;
 
                     $('.process .progress-bar').css('width', `${progressCount}%`);
                     $('.process span.status-percent').text(`${progressCount}%`);
+
+                    if (isCancelled) {
+                        clearInterval(monitorProgressInterval);
+
+                        $('.finish-process-container .success-count').text(importedCount);
+
+                        $('.process .progress-bar').css('width', '100%');
+                        $('.process span.status-percent').text('100%');
+                        $('.process span.status-text').text('Processo de importação cancelado.');
+
+                        setTimeout(() => {
+                            $('.process-container').hide();
+                            $('.finish-process-container').show();
+
+                            $('#btn-cancel-import').hide();
+                            $('.close-modal').show();
+                            $('.close-modal').text('Fechar');
+                            $('.close-modal').prop('disabled', false);
+                            $('.close-modal').off().click(() => location.reload());
+                        }, 1250);
+
+                        return;
+                    }
 
                     if (progressCount == 100) {
                         clearInterval(monitorProgressInterval);
@@ -247,13 +286,15 @@
                             $('.process-container').hide();
                             $('.finish-process-container').show();
 
+                            $('#btn-cancel-import').hide();
+                            $('.close-modal').show();
                             $('.close-modal').text('Fechar');
                             $('.close-modal').prop('disabled', false);
                             $('.close-modal').off().click(() => location.reload());
                         }, 1250);
                     }
 
-                }, 2500);
+                }, 2000);
             }
             catch (error) {
                 console.error(error);
@@ -267,6 +308,8 @@
                     $('.process-container').hide();
                     $('.finish-process-container').show();
 
+                    $('#btn-cancel-import').hide();
+                    $('.close-modal').show();
                     $('.close-modal').text('Fechar');
                     $('.close-modal').prop('disabled', false);
                     $('.close-modal').off().click(() => location.reload());

--- a/XerifeTv.CMS/Views/Series/_ImportEpisodesProgressModal.cshtml
+++ b/XerifeTv.CMS/Views/Series/_ImportEpisodesProgressModal.cshtml
@@ -50,8 +50,14 @@
             </div>
 
             <div class="modal-footer">
+                <button id="btn-cancel-import"
+                        type="button"
+                        class="btn btn-outline-danger shadow-sm">
+                    Cancelar
+                </button>
+
                 <button type="button"
-                        class="btn btn-success close-modal"
+                        class="btn btn-success close-modal shadow-sm"
                         disabled>
                     Processando...
                 </button>


### PR DESCRIPTION
Implement import cancellation for IMDB episode imports, allowing users to stop long-running operations directly from the UI.

### Backend
- add `CancelImport` endpoint to `SeriesController` with authorization
- introduce `CancelImportEpisodesRequestDto`
- extend `IEpisodesImporter` with `CancelImportAsync`
- implement cancellation support in `EpisodesImdbImporter`
- expose `IsCancelled` in `ImportEpisodesResponseDto`

### Frontend
- add cancel button to the import progress modal
- implement request flow for cancelling active imports
- update progress modal to reflect cancelled state
- improve UX by handling cancellation feedback and process status consistently