### PR TITLE
feat(api-v2): change home featured content to return a list instead of a single object

### DIFF
--- a/XerifeTv.CMS/Controllers/ContentAPI/Content.v2.Controller.cs
+++ b/XerifeTv.CMS/Controllers/ContentAPI/Content.v2.Controller.cs
@@ -302,12 +302,11 @@ public class ContentV2Controller(
         {
             var response = await service.GetHomeContentAsync();
 
-            if (!response.IsSuccess) return null;
+            if (!response.IsSuccess) return null; 
 
             return new
             {
-                featured = response.Data?.FeaturedContent,
-                featuredType = response.Data?.FeaturedContentType == EFeaturedContentType.MOVIE ? "movie" : "series",
+                featureds = response.Data?.FeaturedContents,
                 movieCategories = response.Data?.MovieCategores,
                 seriesCategories = response.Data?.SeriesCategores
             };

--- a/XerifeTv.CMS/Modules/Content/Dtos/Response/GetHomeContentV2ResponseDto.cs
+++ b/XerifeTv.CMS/Modules/Content/Dtos/Response/GetHomeContentV2ResponseDto.cs
@@ -2,14 +2,9 @@
 
 public class GetHomeContentV2ResponseDto
 {
-    public object? FeaturedContent { get; set; }
-    public EFeaturedContentType FeaturedContentType { get; set; }
+    public List<FeaturedContent> FeaturedContents = [];
     public string[] MovieCategores { get; set; } = [];
     public string[] SeriesCategores { get; set; } = [];
 }
 
-public enum EFeaturedContentType
-{
-    MOVIE,
-    SERIES
-}
+public record FeaturedContent(object? Content, string Type);

--- a/XerifeTv.CMS/Modules/Content/Interfaces/IContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/Interfaces/IContentV2Service.cs
@@ -18,7 +18,7 @@ public interface IContentV2Service
     Task<Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>> GetSeriesRecommendedAsync(string seriesId);
     Task<Result<IEnumerable<MovieContentV2ResponseDto>>> GetMoviesByTermAsync(string searchTerm, int limit = 10);
     Task<Result<IEnumerable<SeriesSummaryContentV2ResponseDto>>> GetSeriesByTermAsync(string searchTerm, int limit = 10);
-    Task<Result<GetHomeContentV2ResponseDto>> GetHomeContentAsync();
+    Task<Result<GetHomeContentV2ResponseDto>> GetHomeContentAsync(int featuredContentsLimit = 5);
     Task<Result<PagedList<ItemsByCategory<MovieContentV2ResponseDto>>>> GetMoviesByCategoriesListAsync(List<string> categories, int page, int pageSize = 1);
     Task<Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>> GetSeriesByCategoriesListAsync(List<string> categories, int page, int pageSize = 1);
 }

--- a/XerifeTv.CMS/Modules/Content/Services/ContentV2Service.cs
+++ b/XerifeTv.CMS/Modules/Content/Services/ContentV2Service.cs
@@ -259,48 +259,40 @@ public class ContentV2Service(
         }
     }
 
-    public async Task<Result<GetHomeContentV2ResponseDto>> GetHomeContentAsync()
+    public async Task<Result<GetHomeContentV2ResponseDto>> GetHomeContentAsync(int featuredContentsLimit = 5)
     {
         try
         {
-            var random = new Random();
-            int randomValue = random.Next(1, 21);
+            var moviesResult = await movieRepository.GetByFilterAsync(new(
+                filter: EMovieSearchFilter.TITLE,
+                order: EMovieOrderFilter.REGISTRATION_DATE_DESC,
+                search: string.Empty,
+                limitResults: featuredContentsLimit,
+                currentPage: 1,
+                isIncludeDisabled: false));
 
-            bool isMovieFeatured = randomValue % 2 == 0;
+            var movieContents = moviesResult.Items
+                .Select(i => MovieContentV2ResponseDto.FromEntity(i, configuration["SecuritySettings:ContentEncryptionKey"]!))
+                .Select(c => new FeaturedContent(c, "movie"))
+                .ToList();
 
-            object? featuredContent;
-            EFeaturedContentType featuredType = EFeaturedContentType.MOVIE;
+            var seriesResult = await seriesRepository.GetByFilterAsync(new(
+                 filter: ESeriesSearchFilter.TITLE,
+                 search: string.Empty,
+                 limitResults: featuredContentsLimit,
+                 currentPage: 1,
+                 isIncludeDisabled: false));
 
-            if (isMovieFeatured)
-            {
-                var moviesResult = await movieRepository.GetByFilterAsync(new(
-                    filter: EMovieSearchFilter.TITLE,
-                    order: EMovieOrderFilter.REGISTRATION_DATE_DESC,
-                    search: string.Empty,
-                    limitResults: 1,
-                    currentPage: 1,
-                    isIncludeDisabled: false));
+            var seriesContents = seriesResult.Items
+                .Select(SeriesSummaryContentV2ResponseDto.FromEntity)
+                .Select(c => new FeaturedContent(c, "series"))
+                .ToList();
 
-                featuredContent = moviesResult.Items.Select(
-                    i => MovieContentV2ResponseDto.FromEntity(i, configuration["SecuritySettings:ContentEncryptionKey"]!)).FirstOrDefault();
-            }
-            else
-            {
-                var seriesResult = await seriesRepository.GetByFilterAsync(new(
-                     filter: ESeriesSearchFilter.TITLE,
-                     search: string.Empty,
-                     limitResults: 1,
-                     currentPage: 1,
-                     isIncludeDisabled: false));
-
-                featuredContent = seriesResult.Items.Select(SeriesSummaryContentV2ResponseDto.FromEntity).FirstOrDefault();
-                featuredType = EFeaturedContentType.SERIES;
-            }
+            var featuredContents = InterleaveLists(movieContents, seriesContents);
 
             return Result<GetHomeContentV2ResponseDto>.Success(new()
             {
-                FeaturedContent = featuredContent,
-                FeaturedContentType = featuredType,
+                FeaturedContents = [.. featuredContents.Take(featuredContentsLimit)],
                 MovieCategores = (await GetMoviesCategoriesAsync(6)).Data ?? [],
                 SeriesCategores = (await GetSeriesCategoriesAsync(6)).Data ?? []
             });
@@ -353,6 +345,23 @@ public class ContentV2Service(
         {
             return Result<PagedList<ItemsByCategory<SeriesSummaryContentV2ResponseDto>>>.Failure(new("500", ex.Message));
         }
+    }
+
+    private static List<FeaturedContent> InterleaveLists(List<FeaturedContent> first, List<FeaturedContent> second)
+    {
+        var result = new List<FeaturedContent>(first.Count + second.Count);
+        int maxCount = Math.Max(first.Count, second.Count);
+
+        for (int i = 0; i < maxCount; i++)
+        {
+            if (i < first.Count)
+                result.Add(first[i]);
+
+            if (i < second.Count)
+                result.Add(second[i]);
+        }
+
+        return result;
     }
 }
 


### PR DESCRIPTION
Update the /home endpoint to return featured content as a list of objects instead of a single object, enabling multiple items to be displayed in the hero-banner slides.